### PR TITLE
ci(release): skip prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          release-type: maven
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
       - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.release_created }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,0 @@
-{
-  "prerelease": "true",
-  "release-type": "maven"
-}


### PR DESCRIPTION
this does not seem to work with maven release type. thus I skip it.