### PR TITLE
cli improvements

### DIFF
--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -45,6 +45,13 @@ jobs:
       - name: Build with Maven
         if: github.ref == 'refs/heads/main' || steps.check.outputs.pr_found == 'false'
         run: ./mvnw -B -Pprod verify
+      - name: Upload CLI Artifacts
+        uses: actions/upload-artifact@v6
+        if: github.ref == 'refs/heads/main' || steps.check.outputs.pr_found == 'false'
+        with:
+          name: cli
+          path: toolkit/cli/target/snow-white-*
+          if-no-files-found: error
       - name: Fetch References
         if: github.ref == 'refs/heads/main' || steps.check.outputs.pr_found == 'false'
         run: git fetch --unshallow origin

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -93,7 +93,6 @@ jobs:
         run: ./mvnw -B -Pprod verify
       - name: Upload CLI Artifacts
         uses: actions/upload-artifact@v6
-        if: github.ref == 'refs/heads/main' || steps.check.outputs.pr_found == 'false'
         with:
           name: cli
           path: toolkit/cli/target/snow-white-*

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -91,6 +91,13 @@ jobs:
         working-directory: 'helm/charts/snow-white'
       - name: Build with Maven
         run: ./mvnw -B -Pprod verify
+      - name: Upload CLI Artifacts
+        uses: actions/upload-artifact@v6
+        if: github.ref == 'refs/heads/main' || steps.check.outputs.pr_found == 'false'
+        with:
+          name: cli
+          path: toolkit/cli/target/snow-white-*
+          if-no-files-found: error
       - name: Fetch References
         run: git fetch --unshallow origin
       - name: Cache SonarQube Packages

--- a/dev/snow-white.json
+++ b/dev/snow-white.json
@@ -1,5 +1,4 @@
 {
-  "qualityGate": "basic-coverage",
   "apiInformation": [
     {
       "serviceName": "example-application",
@@ -7,5 +6,7 @@
       "apiVersion": "1.0.0"
     }
   ],
+  "apiNamePath": "info.x-api-name",
+  "qualityGate": "basic-coverage",
   "url": "http://localhost:9000"
 }

--- a/toolkit/cli/bunfig.toml
+++ b/toolkit/cli/bunfig.toml
@@ -4,6 +4,9 @@ coverageDir = "target/coverage"
 coverageReporter = ["text", "lcov"]
 
 # https://bun.sh/docs/test/coverage#exclude-test-files-from-coverage
+coveragePathIgnorePatterns = [
+    'src/clients/**/*.ts'
+]
 coverageSkipTestFiles = true
 
 # https://bun.sh/docs/test/reporters#junit-xml-reporter

--- a/toolkit/cli/pom.xml
+++ b/toolkit/cli/pom.xml
@@ -124,6 +124,19 @@
               <output>${project.build.directory}/generated-sources/openapi/quality-gate-api</output>
             </configuration>
           </execution>
+          <execution>
+            <id>generate-v1-report-api-client</id>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <inputSpec>
+                ${maven.multiModuleProjectDirectory}/microservices/report-coordinator-api/src/main/resources/openapi/v1-report-api.yml
+              </inputSpec>
+              <generatorName>typescript-fetch</generatorName>
+              <output>${project.build.directory}/generated-sources/openapi/report-api</output>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 

--- a/toolkit/cli/src/actions/calculate.spec.ts
+++ b/toolkit/cli/src/actions/calculate.spec.ts
@@ -8,6 +8,7 @@ import { afterAll, beforeEach, describe, expect, it, jest, mock, spyOn } from 'b
 import { exit } from 'node:process';
 
 import type { QualityGateApi } from '../clients/quality-gate-api';
+import type { ReportApi } from '../clients/report-api';
 import type { SanitizedOptions } from '../config/sanitized-options';
 
 import { FetchError, ResponseError } from '../clients/quality-gate-api/runtime';
@@ -26,13 +27,22 @@ const getQualityGateApi = (qualityGateApiMock: unknown): QualityGateApi => {
   return qualityGateApiMock as QualityGateApi;
 };
 
+const getReportApi = (reportApiMock: unknown): ReportApi => {
+  return reportApiMock as ReportApi;
+};
+
 describe('calculate action', () => {
   const qualityGateApiMock = {
     calculateQualityGateRaw: mock(),
   };
 
+  const reportApiMock = {
+    getReportByCalculationId: mock(),
+  };
+
   const defaultOptions: SanitizedOptions = {
     apiInformation: [{ apiName: 'test-api', apiVersion: '1.0.0', serviceName: 'test-service' }],
+    async: true,
     qualityGate: 'test-gate',
     url: 'http://localhost:8080',
   };
@@ -42,13 +52,14 @@ describe('calculate action', () => {
     mockConsoleError.mockReset();
 
     qualityGateApiMock.calculateQualityGateRaw.mockReset();
+    reportApiMock.getReportByCalculationId.mockReset();
   });
 
   afterAll(() => {
     jest.restoreAllMocks();
   });
 
-  describe('successful calculation', () => {
+  describe('successful calculation (async: true)', () => {
     it('should successfully initiate quality gate calculation', async () => {
       const mockLocation = 'http://localhost:8080/api/rest/v1/quality-gates/reports/123-456-789';
       const mockApiResponse = {
@@ -69,7 +80,7 @@ describe('calculate action', () => {
 
       qualityGateApiMock.calculateQualityGateRaw.mockResolvedValue(mockApiResponse);
 
-      await calculate(getQualityGateApi(qualityGateApiMock), defaultOptions);
+      await calculate(getQualityGateApi(qualityGateApiMock), getReportApi(reportApiMock), defaultOptions);
 
       expect(qualityGateApiMock.calculateQualityGateRaw).toHaveBeenCalledWith({
         calculateQualityGateRequest: {
@@ -104,7 +115,7 @@ describe('calculate action', () => {
         lookbackWindow: '24h',
       };
 
-      await calculate(getQualityGateApi(qualityGateApiMock), optionsWithLookback);
+      await calculate(getQualityGateApi(qualityGateApiMock), getReportApi(reportApiMock), optionsWithLookback);
 
       expect(qualityGateApiMock.calculateQualityGateRaw).toHaveBeenCalledWith({
         calculateQualityGateRequest: {
@@ -132,7 +143,7 @@ describe('calculate action', () => {
         attributeFilters: { environment: 'production', region: 'us-west-1' },
       };
 
-      await calculate(getQualityGateApi(qualityGateApiMock), optionsWithFilters);
+      await calculate(getQualityGateApi(qualityGateApiMock), getReportApi(reportApiMock), optionsWithFilters);
 
       expect(qualityGateApiMock.calculateQualityGateRaw).toHaveBeenCalledWith({
         calculateQualityGateRequest: {
@@ -163,7 +174,7 @@ describe('calculate action', () => {
         lookbackWindow: '7d',
       };
 
-      await calculate(getQualityGateApi(qualityGateApiMock), fullOptions);
+      await calculate(getQualityGateApi(qualityGateApiMock), getReportApi(reportApiMock), fullOptions);
 
       expect(qualityGateApiMock.calculateQualityGateRaw).toHaveBeenCalledWith({
         calculateQualityGateRequest: {
@@ -184,11 +195,100 @@ describe('calculate action', () => {
 
       qualityGateApiMock.calculateQualityGateRaw.mockResolvedValue(mockApiResponse);
 
-      await calculate(getQualityGateApi(qualityGateApiMock), defaultOptions);
+      await calculate(getQualityGateApi(qualityGateApiMock), getReportApi(reportApiMock), defaultOptions);
 
       expect(mockConsoleLog).toHaveBeenNthCalledWith(4, expect.stringContaining('✅ Quality-Gate calculation initiated successfully!'));
       expect(mockConsoleLog).not.toHaveBeenCalledWith(expect.stringContaining('Location:'));
       expect(mockConsoleLog).not.toHaveBeenCalledWith(expect.stringContaining('💡  Use the returned URL to check the calculation report.'));
+    });
+  });
+
+  describe('synchronous polling (async: false)', () => {
+    const syncOptions: SanitizedOptions = {
+      ...defaultOptions,
+      async: false,
+    };
+
+    const makeMockApiResponse = (calculationId = '123-456-789') => ({
+      raw: {
+        headers: {
+          get: (name: string) =>
+            name.toLowerCase() === 'location' ? `http://localhost:8080/api/rest/v1/quality-gates/reports/${calculationId}` : null,
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/require-await
+      value: async () => ({
+        calculationId,
+        calculationRequest: {},
+        initiatedAt: new Date(),
+        qualityGateConfigName: 'test-gate',
+        status: 'IN_PROGRESS',
+      }),
+    });
+
+    it('should poll until PASSED and exit successfully', async () => {
+      qualityGateApiMock.calculateQualityGateRaw.mockResolvedValue(makeMockApiResponse());
+
+      reportApiMock.getReportByCalculationId
+        .mockResolvedValueOnce({ calculationId: '123-456-789', status: 'IN_PROGRESS' })
+        .mockResolvedValueOnce({ calculationId: '123-456-789', status: 'PASSED' });
+
+      await calculate(getQualityGateApi(qualityGateApiMock), getReportApi(reportApiMock), syncOptions);
+
+      expect(reportApiMock.getReportByCalculationId).toHaveBeenCalledTimes(2);
+      expect(reportApiMock.getReportByCalculationId).toHaveBeenCalledWith({ calculationId: '123-456-789' });
+      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('⏳  Polling for calculation result...'));
+      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('✅ Quality-Gate passed!'));
+      expect(exit).not.toHaveBeenCalled();
+    });
+
+    it('should poll until FAILED and exit with non-zero code', async () => {
+      qualityGateApiMock.calculateQualityGateRaw.mockResolvedValue(makeMockApiResponse());
+
+      reportApiMock.getReportByCalculationId.mockResolvedValueOnce({ calculationId: '123-456-789', status: 'FAILED' });
+
+      await calculate(getQualityGateApi(qualityGateApiMock), getReportApi(reportApiMock), syncOptions);
+
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('❌  Quality-Gate calculation FAILED!'));
+      expect(exit).toHaveBeenCalledWith(QUALITY_GATE_CALCULATION_FAILED);
+    });
+
+    it('should poll until FINISHED_EXCEPTIONALLY and exit with non-zero code', async () => {
+      qualityGateApiMock.calculateQualityGateRaw.mockResolvedValue(makeMockApiResponse());
+
+      reportApiMock.getReportByCalculationId.mockResolvedValueOnce({
+        calculationId: '123-456-789',
+        stackTrace: 'java.lang.NullPointerException at ...',
+        status: 'FINISHED_EXCEPTIONALLY',
+      });
+
+      await calculate(getQualityGateApi(qualityGateApiMock), getReportApi(reportApiMock), syncOptions);
+
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('❌  Quality-Gate calculation FINISHED_EXCEPTIONALLY!'));
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('java.lang.NullPointerException'));
+      expect(exit).toHaveBeenCalledWith(QUALITY_GATE_CALCULATION_FAILED);
+    });
+
+    it('should poll until TIMED_OUT and exit with non-zero code', async () => {
+      qualityGateApiMock.calculateQualityGateRaw.mockResolvedValue(makeMockApiResponse());
+
+      reportApiMock.getReportByCalculationId.mockResolvedValueOnce({ calculationId: '123-456-789', status: 'TIMED_OUT' });
+
+      await calculate(getQualityGateApi(qualityGateApiMock), getReportApi(reportApiMock), syncOptions);
+
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('❌  Quality-Gate calculation TIMED_OUT!'));
+      expect(exit).toHaveBeenCalledWith(QUALITY_GATE_CALCULATION_FAILED);
+    });
+
+    it('should use calculationId from the response body', async () => {
+      const specificId = 'abc-def-123';
+      qualityGateApiMock.calculateQualityGateRaw.mockResolvedValue(makeMockApiResponse(specificId));
+
+      reportApiMock.getReportByCalculationId.mockResolvedValueOnce({ calculationId: specificId, status: 'PASSED' });
+
+      await calculate(getQualityGateApi(qualityGateApiMock), getReportApi(reportApiMock), syncOptions);
+
+      expect(reportApiMock.getReportByCalculationId).toHaveBeenCalledWith({ calculationId: specificId });
     });
   });
 
@@ -206,7 +306,7 @@ describe('calculate action', () => {
 
       qualityGateApiMock.calculateQualityGateRaw.mockRejectedValue(responseError);
 
-      await calculate(getQualityGateApi(qualityGateApiMock), defaultOptions);
+      await calculate(getQualityGateApi(qualityGateApiMock), getReportApi(reportApiMock), defaultOptions);
 
       expect(mockConsoleError).toHaveBeenNthCalledWith(1, expect.stringContaining('❌  Failed to trigger Quality-Gate calculation!'));
       expect(mockConsoleError).toHaveBeenNthCalledWith(2, expect.stringContaining('Status: 404'));
@@ -227,7 +327,7 @@ describe('calculate action', () => {
 
       qualityGateApiMock.calculateQualityGateRaw.mockRejectedValue(responseError);
 
-      await calculate(getQualityGateApi(qualityGateApiMock), defaultOptions);
+      await calculate(getQualityGateApi(qualityGateApiMock), getReportApi(reportApiMock), defaultOptions);
 
       expect(mockConsoleError).toHaveBeenNthCalledWith(1, expect.stringContaining('❌  Failed to trigger Quality-Gate calculation!'));
       expect(mockConsoleError).toHaveBeenNthCalledWith(2, expect.stringContaining('Status: 501'));
@@ -244,7 +344,7 @@ describe('calculate action', () => {
 
       qualityGateApiMock.calculateQualityGateRaw.mockRejectedValue(fetchError);
 
-      await calculate(getQualityGateApi(qualityGateApiMock), defaultOptions);
+      await calculate(getQualityGateApi(qualityGateApiMock), getReportApi(reportApiMock), defaultOptions);
 
       expect(mockConsoleError).toHaveBeenNthCalledWith(1, expect.stringContaining('❌  Failed to trigger Quality-Gate calculation!'));
       expect(mockConsoleError).toHaveBeenNthCalledWith(2, expect.stringContaining('No response received from server'));
@@ -257,7 +357,7 @@ describe('calculate action', () => {
       const genericError = new Error('Something went wrong');
       qualityGateApiMock.calculateQualityGateRaw.mockRejectedValue(genericError);
 
-      await calculate(getQualityGateApi(qualityGateApiMock), defaultOptions);
+      await calculate(getQualityGateApi(qualityGateApiMock), getReportApi(reportApiMock), defaultOptions);
 
       expect(mockConsoleError).toHaveBeenNthCalledWith(1, expect.stringContaining('❌  Failed to trigger Quality-Gate calculation!'));
       expect(mockConsoleError).toHaveBeenNthCalledWith(2, expect.stringContaining(`Error: ${genericError.message}`));
@@ -269,7 +369,7 @@ describe('calculate action', () => {
       const unknownError = { custom: 'error object' };
       qualityGateApiMock.calculateQualityGateRaw.mockRejectedValue(unknownError);
 
-      await calculate(getQualityGateApi(qualityGateApiMock), defaultOptions);
+      await calculate(getQualityGateApi(qualityGateApiMock), getReportApi(reportApiMock), defaultOptions);
 
       expect(mockConsoleError).toHaveBeenNthCalledWith(1, expect.stringContaining('❌  Failed to trigger Quality-Gate calculation!'));
       expect(mockConsoleError).toHaveBeenNthCalledWith(2, expect.stringContaining(`Error: ${JSON.stringify(unknownError)}`));

--- a/toolkit/cli/src/actions/calculate.spec.ts
+++ b/toolkit/cli/src/actions/calculate.spec.ts
@@ -242,18 +242,18 @@ describe('calculate action', () => {
       expect(exit).not.toHaveBeenCalled();
     });
 
-    it('should poll until FAILED and exit with non-zero code', async () => {
+    it.each(['FAILED', 'TIMED_OUT'])('should poll until %s and exit with non-zero code', async (status: string) => {
       qualityGateApiMock.calculateQualityGateRaw.mockResolvedValue(makeMockApiResponse());
 
-      reportApiMock.getReportByCalculationId.mockResolvedValueOnce({ calculationId: '123-456-789', status: 'FAILED' });
+      reportApiMock.getReportByCalculationId.mockResolvedValueOnce({ calculationId: '123-456-789', status });
 
       await calculate(getQualityGateApi(qualityGateApiMock), getReportApi(reportApiMock), syncOptions);
 
-      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('❌  Quality-Gate calculation FAILED!'));
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining(`❌  Quality-Gate calculation ${status}!`));
       expect(exit).toHaveBeenCalledWith(QUALITY_GATE_CALCULATION_FAILED);
     });
 
-    it('should poll until FINISHED_EXCEPTIONALLY and exit with non-zero code', async () => {
+    it('should poll until  and exit with non-zero code', async () => {
       qualityGateApiMock.calculateQualityGateRaw.mockResolvedValue(makeMockApiResponse());
 
       reportApiMock.getReportByCalculationId.mockResolvedValueOnce({
@@ -266,17 +266,6 @@ describe('calculate action', () => {
 
       expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('❌  Quality-Gate calculation FINISHED_EXCEPTIONALLY!'));
       expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('java.lang.NullPointerException'));
-      expect(exit).toHaveBeenCalledWith(QUALITY_GATE_CALCULATION_FAILED);
-    });
-
-    it('should poll until TIMED_OUT and exit with non-zero code', async () => {
-      qualityGateApiMock.calculateQualityGateRaw.mockResolvedValue(makeMockApiResponse());
-
-      reportApiMock.getReportByCalculationId.mockResolvedValueOnce({ calculationId: '123-456-789', status: 'TIMED_OUT' });
-
-      await calculate(getQualityGateApi(qualityGateApiMock), getReportApi(reportApiMock), syncOptions);
-
-      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('❌  Quality-Gate calculation TIMED_OUT!'));
       expect(exit).toHaveBeenCalledWith(QUALITY_GATE_CALCULATION_FAILED);
     });
 

--- a/toolkit/cli/src/actions/calculate.ts
+++ b/toolkit/cli/src/actions/calculate.ts
@@ -8,13 +8,18 @@ import chalk from 'chalk';
 import { exit } from 'node:process';
 
 import type { CalculateQualityGateRequest, QualityGateApi } from '../clients/quality-gate-api';
+import type { ReportApi } from '../clients/report-api';
+import type { ListQualityGateReports200ResponseInner } from '../clients/report-api/models/ListQualityGateReports200ResponseInner';
 import type { SanitizedOptions } from '../config/sanitized-options';
 
 import { FetchError, ResponseError } from '../clients/quality-gate-api/runtime';
+import { ListQualityGateReports200ResponseInnerStatusEnum } from '../clients/report-api/models/ListQualityGateReports200ResponseInner';
 import { QUALITY_GATE_CALCULATION_FAILED } from '../common/exit-codes';
 import { toDtos } from '../entity/mapper/api-information.mapper';
 
-const calculateQualityGates = async (qualityGateApi: QualityGateApi, options: SanitizedOptions): Promise<void> => {
+const POLL_INTERVAL_MS = 2000;
+
+const calculateQualityGates = async (qualityGateApi: QualityGateApi, reportApi: ReportApi, options: SanitizedOptions): Promise<void> => {
   console.log(chalk.blue(`🚀  Starting Quality-Gate calculation for ${options.apiInformation.length} API(s)...`));
   console.log(chalk.gray(`Base URL: ${options.url}`));
 
@@ -48,13 +53,43 @@ const calculateQualityGates = async (qualityGateApi: QualityGateApi, options: Sa
     console.log('');
     console.log(chalk.yellow('💡  Use the returned URL to check the calculation report.'));
   }
+
+  if (!options.async) {
+    const calculationResponse = await apiResponse.value();
+    const calculationId = calculationResponse.calculationId;
+
+    console.log('');
+    await pollCalculationResult(reportApi, calculationId);
+  }
 };
 
-// TODO: https://sonarcloud.io/project/issues?id=bbortt_snow-white&pullRequest=570&issueStatuses=OPEN,CONFIRMED&sinceLeakPeriod=true
+const pollCalculationResult = async (reportApi: ReportApi, calculationId: string): Promise<void> => {
+  console.log(chalk.blue('⏳  Polling for calculation result...'));
+  console.log('');
 
-export const calculate = async (qualityGateApi: QualityGateApi, options: SanitizedOptions): Promise<void> => {
+  let report: ListQualityGateReports200ResponseInner;
+  do {
+    await new Promise<void>(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+    report = await reportApi.getReportByCalculationId({ calculationId });
+    console.log(chalk.gray(`Status: ${report.status}`));
+  } while (report.status === ListQualityGateReports200ResponseInnerStatusEnum.InProgress);
+
+  console.log('');
+
+  if (report.status === ListQualityGateReports200ResponseInnerStatusEnum.Passed) {
+    console.log(chalk.green('✅ Quality-Gate passed!'));
+  } else {
+    console.error(chalk.red(`❌  Quality-Gate calculation ${report.status}!`));
+    if (report.stackTrace) {
+      console.error(chalk.gray(report.stackTrace));
+    }
+    exit(QUALITY_GATE_CALCULATION_FAILED);
+  }
+};
+
+export const calculate = async (qualityGateApi: QualityGateApi, reportApi: ReportApi, options: SanitizedOptions): Promise<void> => {
   try {
-    await calculateQualityGates(qualityGateApi, options);
+    await calculateQualityGates(qualityGateApi, reportApi, options);
   } catch (error: unknown) {
     console.error(chalk.red('❌  Failed to trigger Quality-Gate calculation!'));
     console.log('');

--- a/toolkit/cli/src/actions/upload-prereleases.spec.ts
+++ b/toolkit/cli/src/actions/upload-prereleases.spec.ts
@@ -10,14 +10,12 @@ import { exit } from 'node:process';
 
 import type { ApiIndexApi } from '../clients/api-index-api';
 
-import { INVALID_CONFIG_FORMAT, PRERELEASE_UPLOAD_FAILED } from '../common/exit-codes';
+import { PRERELEASE_UPLOAD_FAILED } from '../common/exit-codes';
 import { scanGlob } from '../common/glob';
-import { resolveConfig } from '../config/resolve-config';
 import {
   DEFAULT_API_NAME_PATH,
   DEFAULT_API_VERSION_PATH,
   DEFAULT_SERVICE_NAME_PATH,
-  resolveUrl,
   uploadPrereleases,
 } from './upload-prereleases';
 
@@ -26,11 +24,6 @@ mock.module('node:process', () => ({
   exit: mock().mockImplementation((code: number) => {
     throw new Error(`Process exited with code ${code}`);
   }),
-}));
-
-// eslint-disable-next-line @typescript-eslint/no-floating-promises
-mock.module('../config/resolve-config', () => ({
-  resolveConfig: mock(),
 }));
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -48,6 +41,7 @@ const mockConsoleWarn = spyOn(console, 'warn');
 const mockConsoleError = spyOn(console, 'error');
 
 const BASE_URL = 'http://localhost:8080';
+
 
 const VALID_YAML = `
 openapi: 3.1.0
@@ -71,49 +65,6 @@ const makeFetchError = (message: string) => Object.assign(new Error(message), { 
 
 const makeApiIndexApi = (ingestApi = mock()): ApiIndexApi => ({ ingestApi }) as unknown as ApiIndexApi;
 
-describe('resolveUrl', () => {
-  beforeEach(() => {
-    // @ts-expect-error TS2339: Property mockClear does not exist on type
-    exit.mockClear();
-    (resolveConfig as any).mockReset();
-  });
-
-  it('uses --url directly without consulting the config file', () => {
-    const result = resolveUrl(BASE_URL);
-
-    expect(resolveConfig).not.toHaveBeenCalled();
-    expect(result).toBe(BASE_URL);
-  });
-
-  it('reads URL from config file when --url is not provided', () => {
-    (resolveConfig as any).mockReturnValue({ url: BASE_URL });
-
-    const result = resolveUrl(undefined);
-
-    expect(resolveConfig).toHaveBeenCalledWith(undefined);
-    expect(result).toBe(BASE_URL);
-  });
-
-  it('passes --config-file path to resolveConfig', () => {
-    (resolveConfig as any).mockReturnValue({ url: BASE_URL });
-
-    resolveUrl(undefined, '/path/to/config.json');
-
-    expect(resolveConfig).toHaveBeenCalledWith('/path/to/config.json');
-  });
-
-  it('exits when URL is absent from the config file', () => {
-    (resolveConfig as any).mockReturnValue({});
-
-    expect(() => resolveUrl(undefined)).toThrow(`Process exited with code ${INVALID_CONFIG_FORMAT}`);
-
-    expect(mockConsoleError).toHaveBeenCalledWith(
-      expect.stringContaining('❌  Snow-White base URL must be defined via --url or in the configuration file.'),
-    );
-    expect(exit).toHaveBeenCalledWith(INVALID_CONFIG_FORMAT);
-  });
-});
-
 describe('upload-prereleases action', () => {
   let mockIngestApi: ReturnType<typeof mock>;
 
@@ -125,7 +76,6 @@ describe('upload-prereleases action', () => {
 
     // @ts-expect-error TS2339: Property mockClear does not exist on type
     exit.mockClear();
-    (resolveConfig as any).mockReset();
     (scanGlob as any).mockReset();
     (readFileSync as any).mockReset();
   });

--- a/toolkit/cli/src/actions/upload-prereleases.spec.ts
+++ b/toolkit/cli/src/actions/upload-prereleases.spec.ts
@@ -221,7 +221,7 @@ metadata:
       );
     });
 
-    it('reports missing api name and counts the file as failed', async () => {
+    it('reports missing api name and counts the file as failed', () => {
       const yamlMissingTitle = `
 openapi: 3.1.0
 info:
@@ -231,11 +231,7 @@ info:
       (scanGlob as any).mockReturnValue(['openapi.yaml']);
       (readFileSync as any).mockReturnValue(yamlMissingTitle);
 
-      try {
-        await uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL });
-      } catch {
-        /* exit() mock throws — expected */
-      }
+      expect(uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL })).rejects.toThrow();
 
       expect(exit).toHaveBeenCalledWith(PRERELEASE_UPLOAD_FAILED);
       expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('❌  openapi.yaml: Missing required metadata fields.'));
@@ -243,7 +239,7 @@ info:
       expect(mockIngestApi).not.toHaveBeenCalled();
     });
 
-    it('reports missing api version and counts the file as failed', async () => {
+    it('reports missing api version and counts the file as failed', () => {
       const yamlMissingVersion = `
 openapi: 3.1.0
 info:
@@ -253,17 +249,13 @@ info:
       (scanGlob as any).mockReturnValue(['openapi.yaml']);
       (readFileSync as any).mockReturnValue(yamlMissingVersion);
 
-      try {
-        await uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL });
-      } catch {
-        /* exit() mock throws — expected */
-      }
+      expect(uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL })).rejects.toThrow();
 
       expect(exit).toHaveBeenCalledWith(PRERELEASE_UPLOAD_FAILED);
       expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining(`'${DEFAULT_API_VERSION_PATH}' not found or empty.`));
     });
 
-    it('reports missing service name and counts the file as failed', async () => {
+    it('reports missing service name and counts the file as failed', () => {
       const yamlMissingServiceName = `
 openapi: 3.1.0
 info:
@@ -273,25 +265,17 @@ info:
       (scanGlob as any).mockReturnValue(['openapi.yaml']);
       (readFileSync as any).mockReturnValue(yamlMissingServiceName);
 
-      try {
-        await uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL });
-      } catch {
-        /* exit() mock throws — expected */
-      }
+      expect(uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL })).rejects.toThrow();
 
       expect(exit).toHaveBeenCalledWith(PRERELEASE_UPLOAD_FAILED);
       expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining(`'${DEFAULT_SERVICE_NAME_PATH}' not found or empty.`));
     });
 
-    it('reports all missing metadata fields when none are present', async () => {
+    it('reports all missing metadata fields when none are present', () => {
       (scanGlob as any).mockReturnValue(['openapi.yaml']);
       (readFileSync as any).mockReturnValue('openapi: 3.1.0');
 
-      try {
-        await uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL });
-      } catch {
-        /* exit() mock throws — expected */
-      }
+      expect(uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL })).rejects.toThrow();
 
       expect(exit).toHaveBeenCalledWith(PRERELEASE_UPLOAD_FAILED);
       expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('❌  openapi.yaml: Missing required metadata fields.'));
@@ -317,17 +301,13 @@ info:
       );
     });
 
-    it('counts a file read error as a failed upload', async () => {
+    it('counts a file read error as a failed upload', () => {
       (scanGlob as any).mockReturnValue(['unreadable.yaml']);
       (readFileSync as any).mockImplementation(() => {
         throw new Error('EACCES: permission denied');
       });
 
-      try {
-        await uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL });
-      } catch {
-        /* exit() mock throws — expected */
-      }
+      expect(uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL })).rejects.toThrow();
 
       expect(exit).toHaveBeenCalledWith(PRERELEASE_UPLOAD_FAILED);
       expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('❌  unreadable.yaml: Upload failed.'));
@@ -342,14 +322,10 @@ info:
       (readFileSync as any).mockReturnValue(VALID_YAML);
     });
 
-    it('logs status and message body on HTTP error with message', async () => {
+    it('logs status and message body on HTTP error with message', () => {
       mockIngestApi.mockRejectedValue(makeResponseError(409, 'Conflict', { message: 'API already exists as stable' }));
 
-      try {
-        await uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL });
-      } catch {
-        /* exit() mock throws — expected */
-      }
+      expect(uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL })).rejects.toThrow();
 
       expect(exit).toHaveBeenCalledWith(PRERELEASE_UPLOAD_FAILED);
       expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('❌  openapi.yaml: Upload failed.'));
@@ -357,55 +333,51 @@ info:
       expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('\t  Details: API already exists as stable'));
     });
 
-    it('logs status and statusText on HTTP error without message body', async () => {
+    it('ignores conflict HTTP status with error message when flag is set', async () => {
+      mockIngestApi.mockRejectedValue(makeResponseError(409, 'Conflict', { message: 'API already exists as stable' }));
+
+      await uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', ignoreExisting: true, url: BASE_URL });
+
+      expect(exit).not.toHaveBeenCalled();
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
+        expect.stringContaining('openapi.yaml: Ignoring already existing my-service/My Test API@1.2.3'),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('Upload complete: 0 succeeded, 1 failed.'));
+    });
+
+    it('logs status and statusText on HTTP error without message body', () => {
       mockIngestApi.mockRejectedValue(makeResponseError(500, 'Internal Server Error', null));
 
-      try {
-        await uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL });
-      } catch {
-        /* exit() mock throws — expected */
-      }
+      expect(uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL })).rejects.toThrow();
 
       expect(exit).toHaveBeenCalledWith(PRERELEASE_UPLOAD_FAILED);
       expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('\t  Status: 500'));
       expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('\t  Error: Internal Server Error'));
     });
 
-    it('logs network error when no response received', async () => {
+    it('logs network error when no response received', () => {
       mockIngestApi.mockRejectedValue(makeFetchError('Network Error'));
 
-      try {
-        await uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL });
-      } catch {
-        /* exit() mock throws — expected */
-      }
+      expect(uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL })).rejects.toThrow();
 
       expect(exit).toHaveBeenCalledWith(PRERELEASE_UPLOAD_FAILED);
       expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('\t  No response received from server.'));
       expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('\t  Check if the service is running and accessible.'));
     });
 
-    it('logs message for generic Error instances', async () => {
+    it('logs message for generic Error instances', () => {
       mockIngestApi.mockRejectedValue(new Error('Unexpected failure'));
 
-      try {
-        await uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL });
-      } catch {
-        /* exit() mock throws — expected */
-      }
+      expect(uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL })).rejects.toThrow();
 
       expect(exit).toHaveBeenCalledWith(PRERELEASE_UPLOAD_FAILED);
       expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('\t  Error: Unexpected failure'));
     });
 
-    it('serialises non-Error thrown values', async () => {
+    it('serialises non-Error thrown values', () => {
       mockIngestApi.mockRejectedValue({ custom: 'error object' });
 
-      try {
-        await uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL });
-      } catch {
-        /* exit() mock throws — expected */
-      }
+      expect(uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL })).rejects.toThrow();
 
       expect(exit).toHaveBeenCalledWith(PRERELEASE_UPLOAD_FAILED);
       expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('\t  Error: {"custom":"error object"}'));
@@ -413,16 +385,12 @@ info:
   });
 
   describe('exit behaviour', () => {
-    it('exits with PRERELEASE_UPLOAD_FAILED when at least one upload fails', async () => {
+    it('exits with PRERELEASE_UPLOAD_FAILED when at least one upload fails', () => {
       (scanGlob as any).mockReturnValue(['openapi.yaml']);
       (readFileSync as any).mockReturnValue(VALID_YAML);
       mockIngestApi.mockRejectedValue(new Error('upload error'));
 
-      try {
-        await uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL });
-      } catch {
-        /* exit() mock throws — expected */
-      }
+      expect(uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL })).rejects.toThrow();
 
       expect(exit).toHaveBeenCalledWith(PRERELEASE_UPLOAD_FAILED);
     });
@@ -437,16 +405,12 @@ info:
       expect(exit).not.toHaveBeenCalled();
     });
 
-    it('processes all files before exiting on partial failure', async () => {
+    it('processes all files before exiting on partial failure', () => {
       (scanGlob as any).mockReturnValue(['good.yaml', 'bad.yaml', 'also-good.yaml']);
       (readFileSync as any).mockReturnValue(VALID_YAML);
       mockIngestApi.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('upload error')).mockResolvedValueOnce(undefined);
 
-      try {
-        await uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL });
-      } catch {
-        /* exit() mock throws — expected */
-      }
+      expect(uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL })).rejects.toThrow();
 
       expect(exit).toHaveBeenCalledWith(PRERELEASE_UPLOAD_FAILED);
       expect(mockIngestApi).toHaveBeenCalledTimes(3);

--- a/toolkit/cli/src/actions/upload-prereleases.spec.ts
+++ b/toolkit/cli/src/actions/upload-prereleases.spec.ts
@@ -12,12 +12,7 @@ import type { ApiIndexApi } from '../clients/api-index-api';
 
 import { PRERELEASE_UPLOAD_FAILED } from '../common/exit-codes';
 import { scanGlob } from '../common/glob';
-import {
-  DEFAULT_API_NAME_PATH,
-  DEFAULT_API_VERSION_PATH,
-  DEFAULT_SERVICE_NAME_PATH,
-  uploadPrereleases,
-} from './upload-prereleases';
+import { DEFAULT_API_NAME_PATH, DEFAULT_API_VERSION_PATH, DEFAULT_SERVICE_NAME_PATH, uploadPrereleases } from './upload-prereleases';
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 mock.module('node:process', () => ({
@@ -36,12 +31,12 @@ mock.module('node:fs', () => ({
   readFileSync: mock(),
 }));
 
+const mockConsoleDebug = spyOn(console, 'debug');
 const mockConsoleLog = spyOn(console, 'log');
 const mockConsoleWarn = spyOn(console, 'warn');
 const mockConsoleError = spyOn(console, 'error');
 
 const BASE_URL = 'http://localhost:8080';
-
 
 const VALID_YAML = `
 openapi: 3.1.0
@@ -69,9 +64,11 @@ describe('upload-prereleases action', () => {
   let mockIngestApi: ReturnType<typeof mock>;
 
   beforeEach(() => {
+    mockConsoleDebug.mockReset();
     mockConsoleLog.mockReset();
     mockConsoleWarn.mockReset();
     mockConsoleError.mockReset();
+
     mockIngestApi = mock();
 
     // @ts-expect-error TS2339: Property mockClear does not exist on type
@@ -279,7 +276,7 @@ info:
 
       expect(exit).toHaveBeenCalledWith(PRERELEASE_UPLOAD_FAILED);
       expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('❌  openapi.yaml: Upload failed.'));
-      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('\t  Status: 409'));
+      expect(mockConsoleDebug).toHaveBeenCalledWith(expect.stringContaining('\t  Status: 409'));
       expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('\t  Details: API already exists as stable'));
     });
 
@@ -290,7 +287,7 @@ info:
 
       expect(exit).not.toHaveBeenCalled();
       expect(mockConsoleWarn).toHaveBeenCalledWith(
-        expect.stringContaining('openapi.yaml: Ignoring already existing my-service/My Test API@1.2.3'),
+        expect.stringContaining('\t  ⚠️ Ignoring already existing my-service/My Test API@1.2.3'),
       );
       expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('Upload complete: 0 succeeded, 1 failed.'));
     });
@@ -301,7 +298,7 @@ info:
       expect(uploadPrereleases(makeApiIndexApi(mockIngestApi), { globPattern: '*.yaml', url: BASE_URL })).rejects.toThrow();
 
       expect(exit).toHaveBeenCalledWith(PRERELEASE_UPLOAD_FAILED);
-      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('\t  Status: 500'));
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('❌  openapi.yaml: Upload failed.'));
       expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('\t  Error: Internal Server Error'));
     });
 

--- a/toolkit/cli/src/actions/upload-prereleases.ts
+++ b/toolkit/cli/src/actions/upload-prereleases.ts
@@ -12,9 +12,8 @@ import { exit } from 'node:process';
 import type { ApiIndexApi, GetAllApis200ResponseInner, GetAllApis500Response } from '../clients/api-index-api';
 
 import { GetAllApis200ResponseInnerApiTypeEnum } from '../clients/api-index-api';
-import { INVALID_CONFIG_FORMAT, PRERELEASE_UPLOAD_FAILED } from '../common/exit-codes';
+import { PRERELEASE_UPLOAD_FAILED } from '../common/exit-codes';
 import { scanGlob } from '../common/glob';
-import { resolveConfig } from '../config/resolve-config';
 
 // Default JSON paths mirror the api-sync-job's ArtifactoryProperties defaults.
 // The api-sync-job uses a parsed OpenAPI object model where extension fields are
@@ -33,19 +32,6 @@ export interface UploadPrereleasesOptions {
   serviceNamePath?: string;
   ignoreExisting?: boolean;
 }
-
-export const resolveUrl = (cliUrl?: string, configFile?: string): string => {
-  if (cliUrl) {
-    return cliUrl;
-  }
-
-  const { url } = resolveConfig(configFile);
-  if (!url) {
-    console.error(chalk.red('❌  Snow-White base URL must be defined via --url or in the configuration file.'));
-    exit(INVALID_CONFIG_FORMAT);
-  }
-  return url;
-};
 
 const getNestedValue = (obj: unknown, path: string): string | undefined => {
   const parts = path.split('.');

--- a/toolkit/cli/src/actions/upload-prereleases.ts
+++ b/toolkit/cli/src/actions/upload-prereleases.ts
@@ -122,17 +122,18 @@ export const uploadPrereleases = async (apiIndexApi: ApiIndexApi, options: Uploa
       console.error(chalk.red(`❌  ${file}: Upload failed.`));
 
       if (isResponseError(error)) {
-        console.error(chalk.red(`\t  Status: ${error.response.status}`));
-
         if (error.response.status === 409 && ignoreExisting) {
-          console.warn(chalk.yellow(`⚠️  ${file}: Ignoring already existing ${serviceName}/${apiName}@${apiVersion}`));
+          console.warn(chalk.yellow(`\t  ⚠️ Ignoring already existing ${serviceName}/${apiName}@${apiVersion}`));
           ignoredCount++;
           // Subtract from failed count, because we later increase it anyway
           failCount--;
         } else {
+          console.debug(chalk.red(`\t  Status: ${error.response.status}`));
           const body = (await error.response.json().catch(() => null)) as GetAllApis500Response | undefined;
           if (body) {
             console.error(chalk.red(`\t  Details: ${(body as { message: string }).message}`));
+          } else if (error.response.status === 409) {
+            console.error(chalk.red(`\t  Error: This API specification has already been indexed!`));
           } else {
             console.error(chalk.red(`\t  Error: ${error.response.statusText}`));
           }

--- a/toolkit/cli/src/actions/upload-prereleases.ts
+++ b/toolkit/cli/src/actions/upload-prereleases.ts
@@ -31,6 +31,7 @@ export interface UploadPrereleasesOptions {
   apiNamePath?: string;
   apiVersionPath?: string;
   serviceNamePath?: string;
+  ignoreExisting?: boolean;
 }
 
 export const resolveUrl = (cliUrl?: string, configFile?: string): string => {
@@ -65,7 +66,7 @@ const isResponseError = (error: unknown): error is Error & { response: Response 
 const isFetchError = (error: unknown): boolean => error instanceof TypeError || (error instanceof Error && error.name === 'FetchError');
 
 export const uploadPrereleases = async (apiIndexApi: ApiIndexApi, options: UploadPrereleasesOptions): Promise<void> => {
-  const { globPattern, url } = options;
+  const { globPattern, ignoreExisting, url } = options;
   const apiNamePath = options.apiNamePath ?? DEFAULT_API_NAME_PATH;
   const apiVersionPath = options.apiVersionPath ?? DEFAULT_API_VERSION_PATH;
   const serviceNamePath = options.serviceNamePath ?? DEFAULT_SERVICE_NAME_PATH;
@@ -87,15 +88,20 @@ export const uploadPrereleases = async (apiIndexApi: ApiIndexApi, options: Uploa
 
   let successCount = 0;
   let failCount = 0;
+  let ignoredCount = 0;
 
   for (const file of files) {
+    let apiName: string | undefined;
+    let apiVersion: string | undefined;
+    let serviceName: string | undefined;
+
     try {
       const content = readFileSync(file, 'utf8');
       const parsed = load(content);
 
-      const apiName = getNestedValue(parsed, apiNamePath);
-      const apiVersion = getNestedValue(parsed, apiVersionPath);
-      const serviceName = getNestedValue(parsed, serviceNamePath);
+      apiName = getNestedValue(parsed, apiNamePath);
+      apiVersion = getNestedValue(parsed, apiVersionPath);
+      serviceName = getNestedValue(parsed, serviceNamePath);
 
       if (!apiName || !apiVersion || !serviceName) {
         console.error(chalk.red(`❌  ${file}: Missing required metadata fields.`));
@@ -131,11 +137,19 @@ export const uploadPrereleases = async (apiIndexApi: ApiIndexApi, options: Uploa
 
       if (isResponseError(error)) {
         console.error(chalk.red(`\t  Status: ${error.response.status}`));
-        const body = (await error.response.json().catch(() => null)) as GetAllApis500Response | undefined;
-        if (body) {
-          console.error(chalk.red(`\t  Details: ${(body as { message: string }).message}`));
+
+        if (error.response.status === 409 && ignoreExisting) {
+          console.warn(chalk.yellow(`⚠️  ${file}: Ignoring already existing ${serviceName}/${apiName}@${apiVersion}`));
+          ignoredCount++;
+          // Subtract from failed count, because we later increase it anyway
+          failCount--;
         } else {
-          console.error(chalk.red(`\t  Error: ${error.response.statusText}`));
+          const body = (await error.response.json().catch(() => null)) as GetAllApis500Response | undefined;
+          if (body) {
+            console.error(chalk.red(`\t  Details: ${(body as { message: string }).message}`));
+          } else {
+            console.error(chalk.red(`\t  Error: ${error.response.statusText}`));
+          }
         }
       } else if (isFetchError(error)) {
         console.error(chalk.red('\t  No response received from server.'));
@@ -149,7 +163,7 @@ export const uploadPrereleases = async (apiIndexApi: ApiIndexApi, options: Uploa
   }
 
   console.log('');
-  console.log(chalk.blue(`Upload complete: ${successCount} succeeded, ${failCount} failed.`));
+  console.log(chalk.blue(`Upload complete: ${successCount} succeeded, ${failCount + ignoredCount} failed.`));
 
   if (failCount > 0) {
     exit(PRERELEASE_UPLOAD_FAILED);

--- a/toolkit/cli/src/api/report-api.ts
+++ b/toolkit/cli/src/api/report-api.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Timon Borter <timon.borter@gmx.ch>
+ * Licensed under the Polyform Small Business License 1.0.0
+ * See LICENSE file for full details.
+ */
+
+import { Configuration, ReportApi } from '../clients/report-api';
+
+export const getReportApi = (baseUrl: string): ReportApi => new ReportApi(new Configuration({ basePath: baseUrl }));

--- a/toolkit/cli/src/cli.spec.ts
+++ b/toolkit/cli/src/cli.spec.ts
@@ -309,7 +309,6 @@ describe('CLI', () => {
         assertThatBasicInformationIsBeingPrinted(cliResult, QUALITY_GATE_CALCULATION_FAILED);
 
         expect(cliResult.stderr).toContain('❌  Failed to trigger Quality-Gate calculation!');
-        expect(cliResult.stderr).toContain('Status: 500');
         expect(cliResult.stderr).toContain('Error: Server Error');
 
         const requests = await wiremock.getRequestsForAPI('POST', `/api/rest/v1/quality-gates/${qualityGateConfigName}/calculate`);
@@ -466,7 +465,6 @@ info:
         expect(cliResult.exitCode).not.toBe(0);
         expect(cliResult.stderr).toContain('❌');
         expect(cliResult.stderr).toContain('Upload failed.');
-        expect(cliResult.stderr).toContain('Status: 409');
         expect(cliResult.stderr).toContain('Details: API already exists as a stable release');
         expect(cliResult.stdout).toContain('Upload complete: 0 succeeded, 1 failed.');
       } finally {
@@ -498,7 +496,6 @@ info:
         expect(cliResult.exitCode).toBe(0);
         expect(cliResult.stderr).toContain('❌');
         expect(cliResult.stderr).toContain('Upload failed.');
-        expect(cliResult.stderr).toContain('Status: 409');
         expect(cliResult.stderr).toContain('Ignoring already existing integration-test-service/Integration Test API@2.0.0');
         expect(cliResult.stdout).toContain('Upload complete: 0 succeeded, 1 failed.');
       } finally {

--- a/toolkit/cli/src/cli.spec.ts
+++ b/toolkit/cli/src/cli.spec.ts
@@ -376,8 +376,6 @@ describe('CLI', () => {
         WIREMOCK_URL,
       ]);
 
-      console.debug(`Output: ${JSON.stringify(cliResult)}`);
-
       expect(cliResult.exitCode, cliResult.stderr).toBe(0);
       expect(cliResult.stdout).toContain('⏳  Polling for calculation result...');
       expect(cliResult.stdout).toContain('✅ Quality-Gate passed!');
@@ -465,13 +463,43 @@ info:
 
         const cliResult = await executeCLICommand(['upload-prereleases', '--prerelease-specs', tmpSpecFilename, '--url', WIREMOCK_URL]);
 
-        console.debug(`Output: ${cliResult.stderr}`);
-
         expect(cliResult.exitCode).not.toBe(0);
         expect(cliResult.stderr).toContain('❌');
         expect(cliResult.stderr).toContain('Upload failed.');
         expect(cliResult.stderr).toContain('Status: 409');
         expect(cliResult.stderr).toContain('Details: API already exists as a stable release');
+        expect(cliResult.stdout).toContain('Upload complete: 0 succeeded, 1 failed.');
+      } finally {
+        unlinkSync(tmpSpecFilename);
+      }
+    });
+
+    it('should ignore previously indexed api specifications when flag is set', async () => {
+      const tmpSpecFilename = `temp-spec-${randomBytes(8).toString('hex')}.yaml`;
+      writeFileSync(tmpSpecFilename, VALID_OPENAPI_YAML);
+
+      try {
+        const mockResponse: IWireMockResponse = {
+          body: { message: 'API already exists as a stable release' },
+          headers: { 'Content-Type': 'application/json' },
+          status: 409,
+        };
+        await wiremock.register({ endpoint: '/api/rest/v1/apis', method: 'POST' }, mockResponse);
+
+        const cliResult = await executeCLICommand([
+          'upload-prereleases',
+          '--prerelease-specs',
+          tmpSpecFilename,
+          '--url',
+          WIREMOCK_URL,
+          '--ignore-existing',
+        ]);
+
+        expect(cliResult.exitCode).toBe(0);
+        expect(cliResult.stderr).toContain('❌');
+        expect(cliResult.stderr).toContain('Upload failed.');
+        expect(cliResult.stderr).toContain('Status: 409');
+        expect(cliResult.stderr).toContain('Ignoring already existing integration-test-service/Integration Test API@2.0.0');
         expect(cliResult.stdout).toContain('Upload complete: 0 succeeded, 1 failed.');
       } finally {
         unlinkSync(tmpSpecFilename);

--- a/toolkit/cli/src/cli.spec.ts
+++ b/toolkit/cli/src/cli.spec.ts
@@ -81,7 +81,8 @@ const executeCLICommand = async (
       });
     });
 
-    child.on('error', _ => {
+    child.on('error', e => {
+      console.log('error:', e.message);
       resolve({
         exitCode: 1,
         stderr,
@@ -116,6 +117,7 @@ describe('CLI', () => {
       apiVersion,
       '--url',
       WIREMOCK_URL,
+      '--async',
     ]);
 
   const assertThatBasicInformationIsBeingPrinted = (
@@ -135,7 +137,7 @@ describe('CLI', () => {
     WIREMOCK_URL = `http://localhost:${WIREMOCK_PORT}`;
     wiremock = new WireMock(WIREMOCK_URL);
 
-    console.log(`WireMock started on port ${WIREMOCK_PORT}`);
+    console.log(`Connecting to WireMock on port ${WIREMOCK_PORT}`);
   });
 
   afterEach(() => {
@@ -160,12 +162,12 @@ describe('CLI', () => {
           }),
         );
 
-        return executeCLICommand(['calculate', '--config-file', tmpPath, '--url', WIREMOCK_URL]);
+        return executeCLICommand(['calculate', '--config-file', tmpPath, '--url', WIREMOCK_URL, '--async']);
       },
       title: 'with configuration from file',
     },
   ].forEach(testConfiguration => {
-    describe('command: calculate', () => {
+    describe('command: calculate (fire-and-forget)', () => {
       describe(testConfiguration.title, () => {
         it('should successfully trigger quality gate calculation', async () => {
           const { apiName, apiVersion, serviceName, wireMockRequest } = configureSuccessfulWireMockRequest();
@@ -195,8 +197,6 @@ describe('CLI', () => {
 
           const cliResult = await testConfiguration.cliInvocationCommand(serviceName, apiName, apiVersion);
 
-          console.debug(`Output: ${cliResult.stdout}`);
-
           assertThatBasicInformationIsBeingPrinted(cliResult, 0);
 
           expect(cliResult.stdout).toContain('✅ Quality-Gate calculation initiated successfully!');
@@ -215,7 +215,7 @@ describe('CLI', () => {
     });
 
     describe('error handling', () => {
-      it('should exit when server responds with 404 bad request response', async () => {
+      it('should exit when server responds with 400 bad request response', async () => {
         const { apiName, apiVersion, serviceName, wireMockRequest } = configureSuccessfulWireMockRequest();
 
         const message = 'This is a forced error message!';
@@ -237,8 +237,6 @@ describe('CLI', () => {
         });
 
         const cliResult = await invokeCalculateCommandWithExplicitConfiguration(serviceName, apiName, apiVersion);
-
-        console.debug(`Output: ${cliResult.stdout}`);
 
         assertThatBasicInformationIsBeingPrinted(cliResult, QUALITY_GATE_CALCULATION_FAILED);
 
@@ -276,8 +274,6 @@ describe('CLI', () => {
 
         const cliResult = await invokeCalculateCommandWithExplicitConfiguration(serviceName, apiName, apiVersion);
 
-        console.debug(`Output: ${cliResult.stdout}`);
-
         assertThatBasicInformationIsBeingPrinted(cliResult, QUALITY_GATE_CALCULATION_FAILED);
 
         expect(cliResult.stderr).toContain('❌  Failed to trigger Quality-Gate calculation!');
@@ -310,8 +306,6 @@ describe('CLI', () => {
 
         const cliResult = await invokeCalculateCommandWithExplicitConfiguration(serviceName, apiName, apiVersion);
 
-        console.debug(`Output: ${cliResult.stdout}`);
-
         assertThatBasicInformationIsBeingPrinted(cliResult, QUALITY_GATE_CALCULATION_FAILED);
 
         expect(cliResult.stderr).toContain('❌  Failed to trigger Quality-Gate calculation!');
@@ -324,6 +318,102 @@ describe('CLI', () => {
         const unmatchedRequests = await wiremock.getUnmatchedRequests();
         expect(unmatchedRequests.length).toBe(0);
       });
+    });
+  });
+
+  describe('command: calculate (synchronous polling)', () => {
+    const calculationId = '550e8400-e29b-41d4-a716-446655440000';
+
+    const calculateWireMockRequest: IWireMockRequest & { body: CalculateQualityGateRequest } = {
+      body: { includeApis: [{ apiName: 'user-api', apiVersion: '1.0.0', serviceName: 'user-service' }] },
+      endpoint: `/api/rest/v1/quality-gates/${qualityGateConfigName}/calculate`,
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    };
+
+    const makeCalculateMockResponse = (): IWireMockResponse => ({
+      body: {
+        calculationId,
+        calculationRequest: {
+          includeApis: [{ apiName: 'user-api', apiVersion: '1.0.0', serviceName: 'user-service' }],
+        },
+        initiatedAt: '2026-01-01T00:00:00Z',
+        qualityGateConfigName,
+        status: 'IN_PROGRESS',
+      },
+      headers: {
+        'Content-Type': 'application/json',
+        Location: `${WIREMOCK_URL}/api/rest/v1/quality-gates/reports/${calculationId}`,
+      },
+      status: 202,
+    });
+
+    it('should poll until PASSED and exit with code 0', async () => {
+      await wiremock.register(calculateWireMockRequest, makeCalculateMockResponse(), {
+        requestHeaderFeatures: { 'Content-Type': MatchingAttributes.EqualTo },
+      });
+
+      await wiremock.register(
+        { endpoint: `/api/rest/v1/reports/${calculationId}`, method: 'GET' },
+        {
+          body: { calculationId, qualityGateConfigName, status: 'PASSED' },
+          headers: { 'Content-Type': 'application/json' },
+          status: 200,
+        },
+      );
+
+      const cliResult = await executeCLICommand([
+        'calculate',
+        '--quality-gate',
+        qualityGateConfigName,
+        '--service-name',
+        'user-service',
+        '--api-name',
+        'user-api',
+        '--api-version',
+        '1.0.0',
+        '--url',
+        WIREMOCK_URL,
+      ]);
+
+      console.debug(`Output: ${JSON.stringify(cliResult)}`);
+
+      expect(cliResult.exitCode, cliResult.stderr).toBe(0);
+      expect(cliResult.stdout).toContain('⏳  Polling for calculation result...');
+      expect(cliResult.stdout).toContain('✅ Quality-Gate passed!');
+    });
+
+    it('should poll until FAILED and exit with non-zero code', async () => {
+      await wiremock.register(calculateWireMockRequest, makeCalculateMockResponse(), {
+        requestHeaderFeatures: { 'Content-Type': MatchingAttributes.EqualTo },
+      });
+
+      await wiremock.register(
+        { endpoint: `/api/rest/v1/reports/${calculationId}`, method: 'GET' },
+        {
+          body: { calculationId, qualityGateConfigName, status: 'FAILED' },
+          headers: { 'Content-Type': 'application/json' },
+          status: 200,
+        },
+      );
+
+      const cliResult = await executeCLICommand([
+        'calculate',
+        '--quality-gate',
+        qualityGateConfigName,
+        '--service-name',
+        'user-service',
+        '--api-name',
+        'user-api',
+        '--api-version',
+        '1.0.0',
+        '--url',
+        WIREMOCK_URL,
+      ]);
+
+      expect(cliResult.exitCode).toBe(QUALITY_GATE_CALCULATION_FAILED);
+      expect(cliResult.stdout).toContain('⏳  Polling for calculation result...');
+      expect(cliResult.stderr).toContain('❌  Quality-Gate calculation FAILED!');
     });
   });
 
@@ -345,8 +435,6 @@ info:
         await wiremock.register({ endpoint: '/api/rest/v1/apis', method: 'POST' }, mockResponse);
 
         const cliResult = await executeCLICommand(['upload-prereleases', '--prerelease-specs', tmpSpecFilename, '--url', WIREMOCK_URL]);
-
-        console.debug(`Output: ${cliResult.stdout}`);
 
         expect(cliResult.exitCode, cliResult.stderr).toBe(0);
         expect(cliResult.stdout).toContain('🚀  Uploading prerelease API specifications matching:');
@@ -381,6 +469,7 @@ info:
 
         expect(cliResult.exitCode).not.toBe(0);
         expect(cliResult.stderr).toContain('❌');
+        expect(cliResult.stderr).toContain('Upload failed.');
         expect(cliResult.stderr).toContain('Status: 409');
         expect(cliResult.stderr).toContain('Details: API already exists as a stable release');
         expect(cliResult.stdout).toContain('Upload complete: 0 succeeded, 1 failed.');
@@ -407,8 +496,6 @@ info:
           '--config-file',
           tmpConfigPath,
         ]);
-
-        console.debug(`Output: ${cliResult.stdout}`);
 
         expect(cliResult.exitCode, cliResult.stderr).toBe(0);
         expect(cliResult.stdout).toContain(`Base URL: ${WIREMOCK_URL}`);

--- a/toolkit/cli/src/config/cli-options.ts
+++ b/toolkit/cli/src/config/cli-options.ts
@@ -31,4 +31,9 @@ export interface CliOptions {
    * Can be specified multiple times.
    */
   filter?: string[];
+  /**
+   * Fire-and-forget mode: skip polling for the calculation result.
+   * When false (default), the CLI polls until the calculation completes.
+   */
+  async?: boolean;
 }

--- a/toolkit/cli/src/config/cli-options.ts
+++ b/toolkit/cli/src/config/cli-options.ts
@@ -23,6 +23,12 @@ export interface CliOptions {
    */
   url?: string;
   /**
+   * JSON path configuration for upload-prereleases command.
+   */
+  apiNamePath?: string;
+  apiVersionPath?: string;
+  serviceNamePath?: string;
+  /**
    * The time window to consider for calculation (e.g., '1h', '24h', '7d').
    */
   lookbackWindow?: string;

--- a/toolkit/cli/src/config/sanitize-configuration.spec.ts
+++ b/toolkit/cli/src/config/sanitize-configuration.spec.ts
@@ -12,7 +12,7 @@ import type { SanitizedOptions } from './sanitized-options';
 
 import { INVALID_CONFIG_FORMAT } from '../common/exit-codes';
 import { resolveConfig } from './resolve-config';
-import { sanitizeConfiguration } from './sanitize-configuration';
+import { sanitizeCalculateOptions } from './sanitize-configuration';
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 mock.module('node:process', () => ({
@@ -103,7 +103,7 @@ describe('sanitizeConfiguration', () => {
     },
   ])('should exit with code 3 when combination of parameters is invalid: %s', (options: Partial<CliOptions>) => {
     // @ts-expect-error TS2345: Argument of type Partial<CliOptions> is not assignable to parameter of type CliOptions
-    expect(() => sanitizeConfiguration(options)).toThrowError('Process exited with code 3');
+    expect(() => sanitizeCalculateOptions(options)).toThrowError('Process exited with code 3');
 
     expect(mockConsoleError).toHaveBeenNthCalledWith(
       1,
@@ -119,7 +119,7 @@ describe('sanitizeConfiguration', () => {
     it('resolves config from exact path if specified', () => {
       (resolveConfig as any).mockReturnValueOnce(sanitizedOptions);
 
-      expect(sanitizeConfiguration({} as CliOptions)).toEqual(sanitizedOptions);
+      expect(sanitizeCalculateOptions({} as CliOptions)).toEqual(sanitizedOptions);
 
       expect(resolveConfig).toHaveBeenCalled();
     });
@@ -134,7 +134,7 @@ describe('sanitizeConfiguration', () => {
     it('should exit with code 3 if file is empty', () => {
       (resolveConfig as any).mockReturnValueOnce({});
 
-      expect(() => sanitizeConfiguration({} as CliOptions)).toThrowError('Process exited with code 3');
+      expect(() => sanitizeCalculateOptions({} as CliOptions)).toThrowError('Process exited with code 3');
 
       expect(resolveConfig).toHaveBeenCalled();
 
@@ -146,7 +146,7 @@ describe('sanitizeConfiguration', () => {
 
       (resolveConfig as any).mockReturnValueOnce({ configFile });
 
-      expect(() => sanitizeConfiguration({ configFile } as CliOptions)).toThrowError('Process exited with code 3');
+      expect(() => sanitizeCalculateOptions({ configFile } as CliOptions)).toThrowError('Process exited with code 3');
 
       expect(resolveConfig).toHaveBeenCalledWith(configFile);
 
@@ -156,7 +156,7 @@ describe('sanitizeConfiguration', () => {
     it.each(incompleteApiInformation)('should exit with code 3 if any property is missing: %s', (options: Partial<CliOptions>) => {
       (resolveConfig as any).mockReturnValueOnce({ apiInformation: [options], qualityGate: 'quality-gate', url: 'url' });
 
-      expect(() => sanitizeConfiguration({ configFile: 'configFile' } as CliOptions)).toThrowError('Process exited with code 3');
+      expect(() => sanitizeCalculateOptions({ configFile: 'configFile' } as CliOptions)).toThrowError('Process exited with code 3');
 
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining('❌  Each API information must contain serviceName, apiName, and apiVersion.'),
@@ -173,7 +173,7 @@ describe('sanitizeConfiguration', () => {
         serviceName: 'test-service',
       });
 
-      expect(() => sanitizeConfiguration({ configFile: 'configFile' } as CliOptions)).toThrowError('Process exited with code 3');
+      expect(() => sanitizeCalculateOptions({ configFile: 'configFile' } as CliOptions)).toThrowError('Process exited with code 3');
 
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining('❌  Snow-White base URL must be defined in the configuration.'),
@@ -190,7 +190,7 @@ describe('sanitizeConfiguration', () => {
         url: 'url',
       });
 
-      expect(() => sanitizeConfiguration({ configFile: 'configFile' } as CliOptions)).toThrowError('Process exited with code 3');
+      expect(() => sanitizeCalculateOptions({ configFile: 'configFile' } as CliOptions)).toThrowError('Process exited with code 3');
 
       expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('❌  Quality-Gate name must be defined in the configuration.'));
 
@@ -206,7 +206,7 @@ describe('sanitizeConfiguration', () => {
       };
       (resolveConfig as any).mockReturnValueOnce(fileConfig);
 
-      const result = sanitizeConfiguration({ url: 'http://cli-url.com' } as CliOptions);
+      const result = sanitizeCalculateOptions({ url: 'http://cli-url.com' } as CliOptions);
 
       expect(result.url).toBe('http://cli-url.com');
       expect(mockConsoleWarn).toHaveBeenCalledWith(expect.stringContaining('⚠️  CLI parameter --url overrides config file value'));
@@ -219,7 +219,7 @@ describe('sanitizeConfiguration', () => {
       };
       (resolveConfig as any).mockReturnValueOnce(fileConfig);
 
-      const result = sanitizeConfiguration({ qualityGate: 'cli-gate' } as CliOptions);
+      const result = sanitizeCalculateOptions({ qualityGate: 'cli-gate' } as CliOptions);
 
       expect(result.qualityGate).toBe('cli-gate');
       expect(mockConsoleWarn).toHaveBeenCalledWith(expect.stringContaining('⚠️  CLI parameter --quality-gate overrides config file value'));
@@ -232,7 +232,7 @@ describe('sanitizeConfiguration', () => {
       };
       (resolveConfig as any).mockReturnValueOnce(fileConfig);
 
-      const result = sanitizeConfiguration({ lookbackWindow: '24h' } as CliOptions);
+      const result = sanitizeCalculateOptions({ lookbackWindow: '24h' } as CliOptions);
 
       expect(result.lookbackWindow).toBe('24h');
       expect(mockConsoleWarn).toHaveBeenCalledWith(
@@ -247,7 +247,7 @@ describe('sanitizeConfiguration', () => {
       };
       (resolveConfig as any).mockReturnValueOnce(fileConfig);
 
-      const result = sanitizeConfiguration({ filter: ['region=us-west-1'] } as CliOptions);
+      const result = sanitizeCalculateOptions({ filter: ['region=us-west-1'] } as CliOptions);
 
       expect(result.attributeFilters).toEqual({ region: 'us-west-1' });
       expect(mockConsoleWarn).toHaveBeenCalledWith(
@@ -262,7 +262,7 @@ describe('sanitizeConfiguration', () => {
       };
       (resolveConfig as any).mockReturnValueOnce(fileConfig);
 
-      const result = sanitizeConfiguration({ url: 'http://same-url.com' } as CliOptions);
+      const result = sanitizeCalculateOptions({ url: 'http://same-url.com' } as CliOptions);
 
       expect(result.url).toBe('http://same-url.com');
       expect(mockConsoleWarn).not.toHaveBeenCalled();
@@ -271,7 +271,7 @@ describe('sanitizeConfiguration', () => {
 
   describe('filter parsing', () => {
     it('should parse multiple filters correctly', () => {
-      const result = sanitizeConfiguration({
+      const result = sanitizeCalculateOptions({
         apiName: 'test-api',
         apiVersion: 'api-version',
         filter: ['environment=production', 'region=us-west-1'],
@@ -287,7 +287,7 @@ describe('sanitizeConfiguration', () => {
     });
 
     it('should warn and skip invalid filter format', () => {
-      const result = sanitizeConfiguration({
+      const result = sanitizeCalculateOptions({
         apiName: 'test-api',
         apiVersion: 'api-version',
         filter: ['invalid-filter', 'valid=filter'],
@@ -301,7 +301,7 @@ describe('sanitizeConfiguration', () => {
     });
 
     it('should handle filter with equals sign in value', () => {
-      const result = sanitizeConfiguration({
+      const result = sanitizeCalculateOptions({
         apiName: 'test-api',
         apiVersion: 'api-version',
         filter: ['query=a=b'],
@@ -316,7 +316,7 @@ describe('sanitizeConfiguration', () => {
 
   describe('lookbackWindow validation', () => {
     it('should accept valid lookback window formats', () => {
-      const result = sanitizeConfiguration({
+      const result = sanitizeCalculateOptions({
         apiName: 'test-api',
         apiVersion: 'api-version',
         lookbackWindow: '24h',
@@ -330,7 +330,7 @@ describe('sanitizeConfiguration', () => {
     });
 
     it('should warn for potentially invalid lookback window format', () => {
-      const result = sanitizeConfiguration({
+      const result = sanitizeCalculateOptions({
         apiName: 'test-api',
         apiVersion: 'api-version',
         lookbackWindow: 'invalid',
@@ -347,7 +347,7 @@ describe('sanitizeConfiguration', () => {
   describe('explicit configuration', () => {
     it('should return sanitized options when all required properties are provided', () => {
       expect(
-        sanitizeConfiguration({
+        sanitizeCalculateOptions({
           apiName: 'test-api',
           apiVersion: 'api-version',
           qualityGate: 'quality-gate',
@@ -362,7 +362,7 @@ describe('sanitizeConfiguration', () => {
     });
 
     it('should include optional lookbackWindow and attributeFilters', () => {
-      const result = sanitizeConfiguration({
+      const result = sanitizeCalculateOptions({
         apiName: 'test-api',
         apiVersion: 'api-version',
         filter: ['env=prod'],
@@ -381,7 +381,7 @@ describe('sanitizeConfiguration', () => {
 
     it.each(incompleteApiInformation)('should exit with code 3 if any property is missing: %s', (options: Partial<CliOptions>) => {
       // @ts-expect-error TS2345: Argument of type Partial<CliOptions> is not assignable to parameter of type CliOptions
-      expect(() => sanitizeConfiguration(options)).toThrowError('Process exited with code 3');
+      expect(() => sanitizeCalculateOptions(options)).toThrowError('Process exited with code 3');
 
       expect(mockConsoleError).toHaveBeenNthCalledWith(
         1,
@@ -397,7 +397,7 @@ describe('sanitizeConfiguration', () => {
     it('should exit with code 3 if no URL is provided', () => {
       // test is being done with explicit configuration, but validation applies to any configuration
       expect(() =>
-        sanitizeConfiguration({
+        sanitizeCalculateOptions({
           apiName: 'test-api',
           apiVersion: 'test-version',
           qualityGate: 'quality-gate',
@@ -415,7 +415,7 @@ describe('sanitizeConfiguration', () => {
     it('should exit with code 3 if no Quality-Gate is provided', () => {
       // test is being done with explicit configuration, but validation applies to any configuration
       expect(() =>
-        sanitizeConfiguration({
+        sanitizeCalculateOptions({
           apiName: 'test-api',
           apiVersion: 'test-version',
           serviceName: 'test-service',
@@ -435,7 +435,7 @@ describe('sanitizeConfiguration', () => {
         openApiSpecs: 'some-glob-pattern',
       };
 
-      expect(() => sanitizeConfiguration(options)).toThrowError('Process exited with code 0');
+      expect(() => sanitizeCalculateOptions(options)).toThrowError('Process exited with code 0');
 
       expect(mockConsoleError).not.toHaveBeenCalled();
       expect(mockConsoleWarn).toHaveBeenCalledWith(
@@ -451,7 +451,7 @@ describe('sanitizeConfiguration', () => {
       const async = true;
 
       expect(
-        sanitizeConfiguration({
+        sanitizeCalculateOptions({
           apiName: 'test-api',
           apiVersion: 'api-version',
           async,

--- a/toolkit/cli/src/config/sanitize-configuration.spec.ts
+++ b/toolkit/cli/src/config/sanitize-configuration.spec.ts
@@ -52,6 +52,7 @@ const sanitizedOptions: SanitizedOptions = {
       serviceName: 'test-service',
     },
   ],
+  async: false,
   qualityGate: 'quality-gate',
   url: 'url',
 };
@@ -442,6 +443,26 @@ describe('sanitizeConfiguration', () => {
       );
 
       expect(exit).toHaveBeenCalledWith(0);
+    });
+  });
+
+  describe('async flag', () => {
+    it('should respect custom async flag value', () => {
+      const async = true;
+
+      expect(
+        sanitizeConfiguration({
+          apiName: 'test-api',
+          apiVersion: 'api-version',
+          async,
+          qualityGate: 'quality-gate',
+          serviceName: 'test-service',
+          url: 'url',
+        }),
+      ).toEqual({
+        ...sanitizedOptions,
+        async,
+      });
     });
   });
 });

--- a/toolkit/cli/src/config/sanitize-configuration.spec.ts
+++ b/toolkit/cli/src/config/sanitize-configuration.spec.ts
@@ -10,9 +10,10 @@ import { exit } from 'node:process';
 import type { CliOptions } from './cli-options';
 import type { SanitizedOptions } from './sanitized-options';
 
+import { DEFAULT_API_NAME_PATH, DEFAULT_API_VERSION_PATH, DEFAULT_SERVICE_NAME_PATH } from '../actions/upload-prereleases';
 import { INVALID_CONFIG_FORMAT } from '../common/exit-codes';
 import { resolveConfig } from './resolve-config';
-import { sanitizeCalculateOptions } from './sanitize-configuration';
+import { sanitizeCalculateOptions, sanitizeUploadPrereleasesOptions } from './sanitize-configuration';
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 mock.module('node:process', () => ({
@@ -64,10 +65,6 @@ describe('sanitizeConfiguration', () => {
 
     // @ts-expect-error TS2339: Property mockClear does not exist on type
     exit.mockClear();
-  });
-
-  afterAll(() => {
-    jest.restoreAllMocks();
   });
 
   it.each([
@@ -463,6 +460,182 @@ describe('sanitizeConfiguration', () => {
         ...sanitizedOptions,
         async,
       });
+    });
+  });
+});
+
+describe('sanitizeUploadPrereleasesOptions', () => {
+  const BASE_URL = 'http://localhost:8080';
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    mockConsoleError.mockReset();
+    mockConsoleWarn.mockReset();
+
+    // @ts-expect-error TS2339: Property mockClear does not exist on type
+    exit.mockClear();
+    // @ts-expect-error TS2339: Property mockReset does not exist on type
+    (resolveConfig as any).mockReset();
+  });
+
+  describe('URL resolution', () => {
+    it('should use CLI url directly without consulting the config file', () => {
+      const result = sanitizeUploadPrereleasesOptions({ prereleaseSpecs: '*.yaml', url: BASE_URL });
+
+      expect(resolveConfig).not.toHaveBeenCalled();
+      expect(result.url).toBe(BASE_URL);
+    });
+
+    it('should read URL from config file when --url is not provided', () => {
+      (resolveConfig as any).mockReturnValueOnce({ url: BASE_URL });
+
+      const result = sanitizeUploadPrereleasesOptions({ prereleaseSpecs: '*.yaml' });
+
+      expect(resolveConfig).toHaveBeenCalledWith(undefined);
+      expect(result.url).toBe(BASE_URL);
+    });
+
+    it('should pass --config-file path to resolveConfig', () => {
+      (resolveConfig as any).mockReturnValueOnce({ url: BASE_URL });
+
+      sanitizeUploadPrereleasesOptions({ configFile: '/path/to/config.json', prereleaseSpecs: '*.yaml' });
+
+      expect(resolveConfig).toHaveBeenCalledWith('/path/to/config.json');
+    });
+
+    it('should exit with code 3 when URL is absent from both CLI and config file', () => {
+      (resolveConfig as any).mockReturnValueOnce({});
+
+      expect(() => sanitizeUploadPrereleasesOptions({ prereleaseSpecs: '*.yaml' })).toThrowError('Process exited with code 3');
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('❌  Snow-White base URL must be defined via --url or in the configuration file.'),
+      );
+      expect(exit).toHaveBeenCalledWith(INVALID_CONFIG_FORMAT);
+    });
+
+    it('should warn when CLI url overrides config file url', () => {
+      (resolveConfig as any).mockReturnValueOnce({ url: 'http://config-url.com' });
+
+      const result = sanitizeUploadPrereleasesOptions({
+        configFile: 'config.json',
+        prereleaseSpecs: '*.yaml',
+        url: 'http://cli-url.com',
+      });
+
+      expect(result.url).toBe('http://cli-url.com');
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
+        expect.stringContaining('⚠️  CLI parameter --url overrides config file value: "http://config-url.com" → "http://cli-url.com"'),
+      );
+    });
+
+    it('should not warn when CLI url matches config file url', () => {
+      (resolveConfig as any).mockReturnValueOnce({ url: BASE_URL });
+
+      const result = sanitizeUploadPrereleasesOptions({ configFile: 'config.json', prereleaseSpecs: '*.yaml', url: BASE_URL });
+
+      expect(result.url).toBe(BASE_URL);
+      expect(mockConsoleWarn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('path parameter resolution', () => {
+    it('should use hardcoded defaults when no CLI or config file values are provided', () => {
+      (resolveConfig as any).mockReturnValueOnce({ url: BASE_URL });
+
+      const result = sanitizeUploadPrereleasesOptions({ prereleaseSpecs: '*.yaml' });
+
+      expect(result.apiNamePath).toBe(DEFAULT_API_NAME_PATH);
+      expect(result.apiVersionPath).toBe(DEFAULT_API_VERSION_PATH);
+      expect(result.serviceNamePath).toBe(DEFAULT_SERVICE_NAME_PATH);
+    });
+
+    it('should read path params from config file as fallback', () => {
+      (resolveConfig as any).mockReturnValueOnce({
+        apiNamePath: 'custom.name',
+        apiVersionPath: 'custom.version',
+        serviceNamePath: 'custom.service',
+        url: BASE_URL,
+      });
+
+      const result = sanitizeUploadPrereleasesOptions({ prereleaseSpecs: '*.yaml' });
+
+      expect(result.apiNamePath).toBe('custom.name');
+      expect(result.apiVersionPath).toBe('custom.version');
+      expect(result.serviceNamePath).toBe('custom.service');
+    });
+
+    it('should use CLI path params over config file values', () => {
+      (resolveConfig as any).mockReturnValueOnce({
+        apiNamePath: 'config.name',
+        apiVersionPath: 'config.version',
+        serviceNamePath: 'config.service',
+        url: BASE_URL,
+      });
+
+      const result = sanitizeUploadPrereleasesOptions({
+        apiNamePath: 'cli.name',
+        apiVersionPath: 'cli.version',
+        configFile: 'config.json',
+        prereleaseSpecs: '*.yaml',
+        serviceNamePath: 'cli.service',
+      });
+
+      expect(result.apiNamePath).toBe('cli.name');
+      expect(result.apiVersionPath).toBe('cli.version');
+      expect(result.serviceNamePath).toBe('cli.service');
+    });
+
+    it('should warn when CLI api-name-path overrides config file value', () => {
+      (resolveConfig as any).mockReturnValueOnce({ apiNamePath: 'config.name', url: BASE_URL });
+
+      sanitizeUploadPrereleasesOptions({ apiNamePath: 'cli.name', configFile: 'config.json', prereleaseSpecs: '*.yaml' });
+
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
+        expect.stringContaining('⚠️  CLI parameter --api-name-path overrides config file value: "config.name" → "cli.name"'),
+      );
+    });
+
+    it('should warn when CLI api-version-path overrides config file value', () => {
+      (resolveConfig as any).mockReturnValueOnce({ apiVersionPath: 'config.version', url: BASE_URL });
+
+      sanitizeUploadPrereleasesOptions({ apiVersionPath: 'cli.version', configFile: 'config.json', prereleaseSpecs: '*.yaml' });
+
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
+        expect.stringContaining('⚠️  CLI parameter --api-version-path overrides config file value: "config.version" → "cli.version"'),
+      );
+    });
+
+    it('should warn when CLI service-name-path overrides config file value', () => {
+      (resolveConfig as any).mockReturnValueOnce({ serviceNamePath: 'config.service', url: BASE_URL });
+
+      sanitizeUploadPrereleasesOptions({ configFile: 'config.json', prereleaseSpecs: '*.yaml', serviceNamePath: 'cli.service' });
+
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
+        expect.stringContaining('⚠️  CLI parameter --service-name-path overrides config file value: "config.service" → "cli.service"'),
+      );
+    });
+  });
+
+  describe('option passthrough', () => {
+    it('should pass through globPattern and ignoreExisting', () => {
+      const result = sanitizeUploadPrereleasesOptions({
+        ignoreExisting: true,
+        prereleaseSpecs: 'services/**/openapi.yaml',
+        url: BASE_URL,
+      });
+
+      expect(result.globPattern).toBe('services/**/openapi.yaml');
+      expect(result.ignoreExisting).toBe(true);
+    });
+
+    it('should default ignoreExisting to false when not provided', () => {
+      const result = sanitizeUploadPrereleasesOptions({ prereleaseSpecs: '*.yaml', url: BASE_URL });
+
+      expect(result.ignoreExisting).toBe(false);
     });
   });
 });

--- a/toolkit/cli/src/config/sanitize-configuration.ts
+++ b/toolkit/cli/src/config/sanitize-configuration.ts
@@ -211,7 +211,7 @@ export const validateConfiguration = (config: SanitizedOptions): SanitizedOption
   return config;
 };
 
-export const sanitizeConfiguration = (options: CliOptions): SanitizedOptions => {
+export const sanitizeCalculateOptions = (options: CliOptions): SanitizedOptions => {
   const config = loadConfigBasedOnType(options);
   return validateConfiguration(config as SanitizedOptions);
 };

--- a/toolkit/cli/src/config/sanitize-configuration.ts
+++ b/toolkit/cli/src/config/sanitize-configuration.ts
@@ -7,9 +7,11 @@
 import chalk from 'chalk';
 import { exit } from 'node:process';
 
+import type { UploadPrereleasesOptions } from '../actions/upload-prereleases';
 import type { CliOptions } from './cli-options';
 import type { SanitizedOptions } from './sanitized-options';
 
+import { DEFAULT_API_NAME_PATH, DEFAULT_API_VERSION_PATH, DEFAULT_SERVICE_NAME_PATH } from '../actions/upload-prereleases';
 import { INVALID_CONFIG_FORMAT } from '../common/exit-codes';
 import { resolveConfig } from './resolve-config';
 
@@ -214,4 +216,70 @@ export const validateConfiguration = (config: SanitizedOptions): SanitizedOption
 export const sanitizeCalculateOptions = (options: CliOptions): SanitizedOptions => {
   const config = loadConfigBasedOnType(options);
   return validateConfiguration(config as SanitizedOptions);
+};
+
+export interface UploadCliOptions {
+  prereleaseSpecs: string;
+  url?: string;
+  configFile?: string;
+  apiNamePath?: string;
+  apiVersionPath?: string;
+  serviceNamePath?: string;
+  ignoreExisting?: boolean;
+}
+
+export const sanitizeUploadPrereleasesOptions = (options: UploadCliOptions): UploadPrereleasesOptions => {
+  let fileConfig: Partial<CliOptions> = {};
+
+  // Load config file when explicitly requested or when URL is not provided via CLI
+  if (options.configFile || !options.url) {
+    fileConfig = resolveConfig(options.configFile) as Partial<CliOptions>;
+  }
+
+  // URL: CLI takes precedence over config file
+  let url: string | undefined = options.url;
+  if (!url) {
+    url = fileConfig.url;
+  } else if (fileConfig.url && fileConfig.url !== url) {
+    console.warn(chalk.yellow(`⚠️  CLI parameter --url overrides config file value: "${fileConfig.url}" → "${url}"`));
+  }
+
+  if (!url) {
+    console.error(chalk.red('❌  Snow-White base URL must be defined via --url or in the configuration file.'));
+    exit(INVALID_CONFIG_FORMAT);
+  }
+
+  // Path params: CLI > config file > hardcoded defaults
+  const apiNamePath = options.apiNamePath ?? fileConfig.apiNamePath ?? DEFAULT_API_NAME_PATH;
+  const apiVersionPath = options.apiVersionPath ?? fileConfig.apiVersionPath ?? DEFAULT_API_VERSION_PATH;
+  const serviceNamePath = options.serviceNamePath ?? fileConfig.serviceNamePath ?? DEFAULT_SERVICE_NAME_PATH;
+
+  if (options.apiNamePath && fileConfig.apiNamePath && fileConfig.apiNamePath !== options.apiNamePath) {
+    console.warn(
+      chalk.yellow(`⚠️  CLI parameter --api-name-path overrides config file value: "${fileConfig.apiNamePath}" → "${options.apiNamePath}"`),
+    );
+  }
+  if (options.apiVersionPath && fileConfig.apiVersionPath && fileConfig.apiVersionPath !== options.apiVersionPath) {
+    console.warn(
+      chalk.yellow(
+        `⚠️  CLI parameter --api-version-path overrides config file value: "${fileConfig.apiVersionPath}" → "${options.apiVersionPath}"`,
+      ),
+    );
+  }
+  if (options.serviceNamePath && fileConfig.serviceNamePath && fileConfig.serviceNamePath !== options.serviceNamePath) {
+    console.warn(
+      chalk.yellow(
+        `⚠️  CLI parameter --service-name-path overrides config file value: "${fileConfig.serviceNamePath}" → "${options.serviceNamePath}"`,
+      ),
+    );
+  }
+
+  return {
+    apiNamePath,
+    apiVersionPath,
+    globPattern: options.prereleaseSpecs,
+    ignoreExisting: options.ignoreExisting ?? false,
+    serviceNamePath,
+    url,
+  };
 };

--- a/toolkit/cli/src/config/sanitize-configuration.ts
+++ b/toolkit/cli/src/config/sanitize-configuration.ts
@@ -98,6 +98,11 @@ const mergeWithCliOverrides = (fileConfig: Partial<SanitizedOptions>, cliOptions
     result.attributeFilters = cliFilters;
   }
 
+  // Async flag: CLI-only, not read from config file
+  if (cliOptions.async !== undefined) {
+    result.async = cliOptions.async;
+  }
+
   return result;
 };
 
@@ -161,11 +166,12 @@ const loadConfigBasedOnType = (options: CliOptions): object => {
     exitWithCodeInvalidConfig();
   }
 
-  const { apiName, apiVersion, lookbackWindow, qualityGate, serviceName, url } = options;
+  const { apiName, apiVersion, async, lookbackWindow, qualityGate, serviceName, url } = options;
   const attributeFilters = parseFilters(options.filter);
 
   return {
     apiInformation: [{ apiName, apiVersion, serviceName }],
+    async: async ?? false,
     attributeFilters,
     lookbackWindow,
     qualityGate,

--- a/toolkit/cli/src/config/sanitized-options.ts
+++ b/toolkit/cli/src/config/sanitized-options.ts
@@ -22,4 +22,9 @@ export interface SanitizedOptions {
    * Key-value map of attributes to filter telemetry data.
    */
   attributeFilters?: Record<string, string>;
+  /**
+   * Fire-and-forget mode: skip polling for the calculation result.
+   * When false (default), the CLI polls until the calculation completes.
+   */
+  async?: boolean;
 }

--- a/toolkit/cli/src/index.ts
+++ b/toolkit/cli/src/index.ts
@@ -15,6 +15,7 @@ import { calculate } from './actions/calculate';
 import { DEFAULT_API_NAME_PATH, DEFAULT_API_VERSION_PATH, DEFAULT_SERVICE_NAME_PATH, resolveUrl, uploadPrereleases } from './actions/upload-prereleases';
 import { getApiIndexApi } from './api/api-index-api';
 import { getQualityGateApi } from './api/quality-gate-api';
+import { getReportApi } from './api/report-api';
 import { sanitizeConfiguration } from './config/sanitize-configuration';
 
 const program = new Command();
@@ -52,10 +53,12 @@ program
   .option('--filter <key=value>', 'Attribute filter for telemetry data (can be repeated)', (value:string, previous: string[]|undefined) => {
     return previous ? [...previous, value] : [value];
   }, [])
+  .option('--async', 'Fire-and-forget: do not poll for the calculation result (default: false)')
   .action(async (options: CliOptions) => {
     const sanitizedOptions = sanitizeConfiguration(options);
     const qualityGateApi = getQualityGateApi(sanitizedOptions.url);
-    await calculate(qualityGateApi, sanitizedOptions);
+    const reportApi = getReportApi(sanitizedOptions.url);
+    await calculate(qualityGateApi, reportApi, sanitizedOptions);
   });
 
 program

--- a/toolkit/cli/src/index.ts
+++ b/toolkit/cli/src/index.ts
@@ -16,7 +16,7 @@ import { DEFAULT_API_NAME_PATH, DEFAULT_API_VERSION_PATH, DEFAULT_SERVICE_NAME_P
 import { getApiIndexApi } from './api/api-index-api';
 import { getQualityGateApi } from './api/quality-gate-api';
 import { getReportApi } from './api/report-api';
-import { sanitizeConfiguration } from './config/sanitize-configuration';
+import { sanitizeCalculateOptions } from './config/sanitize-configuration';
 
 const program = new Command();
 
@@ -53,9 +53,9 @@ program
   .option('--filter <key=value>', 'Attribute filter for telemetry data (can be repeated)', (value:string, previous: string[]|undefined) => {
     return previous ? [...previous, value] : [value];
   }, [])
-  .option('--async', 'Fire-and-forget: do not poll for the calculation result (default: false)')
+  .option('--async', 'Fire-and-forget: do not poll for the calculation result', false)
   .action(async (options: CliOptions) => {
-    const sanitizedOptions = sanitizeConfiguration(options);
+    const sanitizedOptions = sanitizeCalculateOptions(options);
     const qualityGateApi = getQualityGateApi(sanitizedOptions.url);
     const reportApi = getReportApi(sanitizedOptions.url);
     await calculate(qualityGateApi, reportApi, sanitizedOptions);
@@ -66,7 +66,7 @@ program
   .description(
     'Upload one or more API specifications from the local file system as prereleases.\n' +
       'Intended to be called at the start of a pipeline before QA runs.\n' +
-      'Uploaded prereleases are temporary and will be cleaned up asynchronously by the pipeline after it completes.',
+      'Uploaded prereleases are temporary and will be cleaned up asynchronously.',
   )
   .requiredOption('--prerelease-specs <pattern>', 'Glob pattern selecting which specification files to upload (e.g. "services/**/openapi.yaml")')
   .option('--url <baseUrl>', 'Base URL for Snow-White (overrides config file)')
@@ -78,6 +78,7 @@ program
     'JSON path to the service name field in the specification (maps to the x-service-name extension in raw YAML)',
     DEFAULT_SERVICE_NAME_PATH,
   )
+  .option('--ignore-existing', 'Ignore previously indexed API specifications', false)
   .action(
     async (options: {
       prereleaseSpecs: string;
@@ -86,6 +87,7 @@ program
       apiNamePath: string;
       apiVersionPath: string;
       serviceNamePath: string;
+      ignoreExisting:boolean
     }) => {
       const url = resolveUrl(options.url, options.configFile);
       const apiIndexApi = getApiIndexApi(url);
@@ -93,6 +95,7 @@ program
         apiNamePath: options.apiNamePath,
         apiVersionPath: options.apiVersionPath,
         globPattern: options.prereleaseSpecs,
+        ignoreExisting: options.ignoreExisting,
         serviceNamePath: options.serviceNamePath,
         url,
       });

--- a/toolkit/cli/src/index.ts
+++ b/toolkit/cli/src/index.ts
@@ -10,13 +10,18 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 
 import type { CliOptions } from './config/cli-options';
+import type {UploadCliOptions} from './config/sanitize-configuration';
 
 import { calculate } from './actions/calculate';
-import { DEFAULT_API_NAME_PATH, DEFAULT_API_VERSION_PATH, DEFAULT_SERVICE_NAME_PATH, resolveUrl, uploadPrereleases } from './actions/upload-prereleases';
+import { uploadPrereleases } from './actions/upload-prereleases';
 import { getApiIndexApi } from './api/api-index-api';
 import { getQualityGateApi } from './api/quality-gate-api';
 import { getReportApi } from './api/report-api';
-import { sanitizeCalculateOptions } from './config/sanitize-configuration';
+import {
+  sanitizeCalculateOptions,
+  sanitizeUploadPrereleasesOptions
+  
+} from './config/sanitize-configuration';
 
 const program = new Command();
 
@@ -71,35 +76,17 @@ program
   .requiredOption('--prerelease-specs <pattern>', 'Glob pattern selecting which specification files to upload (e.g. "services/**/openapi.yaml")')
   .option('--url <baseUrl>', 'Base URL for Snow-White (overrides config file)')
   .option('--config-file <path>', 'Path to config file (used to resolve --url if not provided directly)')
-  .option('--api-name-path <jsonPath>', 'JSON path to the API name field in the specification', DEFAULT_API_NAME_PATH)
-  .option('--api-version-path <jsonPath>', 'JSON path to the API version field in the specification', DEFAULT_API_VERSION_PATH)
+  .option('--api-name-path <jsonPath>', 'JSON path to the API name field in the specification')
+  .option('--api-version-path <jsonPath>', 'JSON path to the API version field in the specification')
   .option(
     '--service-name-path <jsonPath>',
     'JSON path to the service name field in the specification (maps to the x-service-name extension in raw YAML)',
-    DEFAULT_SERVICE_NAME_PATH,
   )
   .option('--ignore-existing', 'Ignore previously indexed API specifications', false)
-  .action(
-    async (options: {
-      prereleaseSpecs: string;
-      url?: string;
-      configFile?: string;
-      apiNamePath: string;
-      apiVersionPath: string;
-      serviceNamePath: string;
-      ignoreExisting:boolean
-    }) => {
-      const url = resolveUrl(options.url, options.configFile);
-      const apiIndexApi = getApiIndexApi(url);
-      await uploadPrereleases(apiIndexApi, {
-        apiNamePath: options.apiNamePath,
-        apiVersionPath: options.apiVersionPath,
-        globPattern: options.prereleaseSpecs,
-        ignoreExisting: options.ignoreExisting,
-        serviceNamePath: options.serviceNamePath,
-        url,
-      });
-    },
-  );
+  .action(async (options: UploadCliOptions) => {
+    const sanitizedOptions = sanitizeUploadPrereleasesOptions(options);
+    const apiIndexApi = getApiIndexApi(sanitizedOptions.url);
+    await uploadPrereleases(apiIndexApi, sanitizedOptions);
+  });
 
 program.parse();


### PR DESCRIPTION
## add `--async` flag to `calculate` command

Introduce an `--async` flag to the `calculate` command to control whether the CLI polls for the calculation result after triggering.
When `--async` is omitted (the new default), the CLI polls the report-api until the status leaves `IN_PROGRESS`, exiting with a non-zero code on `FAILED`, `TIMED_OUT` or `FINISHED_EXCEPTIONALLY`.
Passing `--async` restores the previous fire-and-forget behavior.

## add `--ignore-existing` flag to `upload-prereleases` command

Introduce an `--ignore-existing` flag to the `upload-rereleases` command.
The flag makes it possible to ignore previously indexed api specifications when using the CLI.
This is especially useful for the monorepository workflow described in https://github.com/bbortt/snow-white/issues/1289, where each feature-branch pipeline must re-upload specifications all over again, not knowing the (publishing-) status of the specifications exactly.