### PR TITLE
cli command "calculate" with glob pattern

### DIFF
--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -18,17 +18,17 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           submodules: true
       - name: Check if PR exists
-        uses: 8BitJonny/gh-get-current-pr@4.0.0
+        uses: 8BitJonny/gh-get-current-pr@4056877062a1f3b624d5d4c2bedefa9cf51435c9 # ratchet:8BitJonny/gh-get-current-pr@4.0.0
         id: check
         with:
           filterOutClosed: true
           filterOutDraft: true
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5
         if: github.ref == 'refs/heads/main' || steps.check.outputs.pr_found == 'false'
         with:
           cache: maven
@@ -46,7 +46,7 @@ jobs:
         if: github.ref == 'refs/heads/main' || steps.check.outputs.pr_found == 'false'
         run: ./mvnw -B -Pprod verify
       - name: Upload CLI Artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # ratchet:actions/upload-artifact@v6
         if: github.ref == 'refs/heads/main' || steps.check.outputs.pr_found == 'false'
         with:
           name: cli
@@ -56,7 +56,7 @@ jobs:
         if: github.ref == 'refs/heads/main' || steps.check.outputs.pr_found == 'false'
         run: git fetch --unshallow origin
       - name: Cache SonarQube Packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5
         if: github.ref == 'refs/heads/main' || steps.check.outputs.pr_found == 'false'
         with:
           path: ~/.sonar/cache
@@ -78,16 +78,16 @@ jobs:
     environment: release
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # ratchet:pnpm/action-setup@v5
         name: Install pnpm
         with:
           run_install: false
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v6
         with:
           cache: 'pnpm'
           node-version: 24

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,9 +14,9 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5
         with:
           cache: maven
           distribution: 'temurin'
@@ -33,12 +33,12 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       - name: Extract Version from Tag
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5
         with:
           cache: maven
           distribution: 'temurin'
@@ -56,7 +56,7 @@ jobs:
           gh release upload "${{  github.ref_name }}" toolkit/cli/target/snow-white-macos-x64
           gh release upload "${{  github.ref_name }}" toolkit/cli/target/snow-white-windows-x64.exe
       - name: 'Login to GitHub Container Registry'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -76,16 +76,16 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Extract Version from Tag
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # ratchet:pnpm/action-setup@v5
         with:
           run_install: false
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v6
         with:
           cache: 'pnpm'
           node-version: '24'
@@ -105,7 +105,7 @@ jobs:
           git config user.name "Timon Borter"
           git config user.email "timon.borter@gmx.ch"
       - name: Release Helm Chart
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # ratchet:helm/chart-releaser-action@v1.7.0
         env:
           CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         with:
@@ -118,7 +118,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           lfs: true
           submodules: true
@@ -126,7 +126,7 @@ jobs:
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5
         with:
           cache: maven
           distribution: 'temurin'
@@ -140,7 +140,7 @@ jobs:
             -Dfrontend.test.skip=true \
             -pl :api-gateway,:api-sync-job,:openapi-coverage-stream -am
       - name: 'Login to GitHub Container Registry'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -165,14 +165,14 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           submodules: true
       - name: Extract Version from Tag
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5
         with:
           cache: maven
           distribution: 'temurin'
@@ -180,7 +180,7 @@ jobs:
       - name: Build with Maven
         run: ./mvnw -B -b smart -T4C -DskipTests -Pprod -pl :${{ matrix.service }} -am clean install
       - name: 'Login to GitHub Container Registry'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/labeler@v6
+      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # ratchet:actions/labeler@v6
   lint:
     name: 'Lint'
     runs-on: ubuntu-latest
@@ -26,13 +26,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # ratchet:pnpm/action-setup@v5
         name: Install pnpm
         with:
           run_install: false
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v6
         with:
           cache: 'pnpm'
           node-version: 24
@@ -49,7 +49,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       - name: Fetch Helm Dependencies
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
@@ -73,11 +73,11 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           submodules: true
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5
         with:
           cache: maven
           distribution: 'temurin'
@@ -92,7 +92,7 @@ jobs:
       - name: Build with Maven
         run: ./mvnw -B -Pprod verify
       - name: Upload CLI Artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # ratchet:actions/upload-artifact@v6
         with:
           name: cli
           path: toolkit/cli/target/snow-white-*
@@ -100,7 +100,7 @@ jobs:
       - name: Fetch References
         run: git fetch --unshallow origin
       - name: Cache SonarQube Packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5
         if: '!steps.check.outputs.number'
         with:
           path: ~/.sonar/cache
@@ -126,18 +126,18 @@ jobs:
       fail-fast: false
     services:
       wiremock:
-        image: wiremock/wiremock:3.13.2-alpine
+        image: index.docker.io/wiremock/wiremock@sha256:53dd996e0625bbaa906102d21fbfe029a209e92fd33862f73b3885a386e5db57 # ratchet:wiremock/wiremock:3.13.2-alpine
         ports:
           - '9000:8080'
         options: --name wiremock
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           lfs: true
           submodules: true
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5
         with:
           cache: maven
           distribution: 'temurin'
@@ -185,14 +185,13 @@ jobs:
       fail-fast: false
     services:
       kafka:
-        image: confluentinc/cp-kafka:8.2.0
+        image: index.docker.io/confluentinc/cp-kafka@sha256:acbbf674f2ed40e5d0a8ca51beb0f00692c866fc22b5ce06f8cadbdc54cd4436 # ratchet:confluentinc/cp-kafka:8.2.0
         env:
           # Cluster / broker identity
           KAFKA_NODE_ID: 1
           KAFKA_BROKER_ID: 1
           CLUSTER_ID: 'NjZmNTk0MDc5OWZjNDQzYW' # run "kafka-storage random-uuid"
           KAFKA_PROCESS_ROLES: 'broker,controller'
-
           # Listener setup
           KAFKA_LISTENERS: 'PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094'
           KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,EXTERNAL://kafka:9094'
@@ -206,11 +205,12 @@ jobs:
           KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
           KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
           KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'
+
         ports:
           - '9092:9092'
           - '9094:9094'
       postgres:
-        image: postgres:18.3-alpine
+        image: index.docker.io/library/postgres@sha256:4da1a4828be12604092fa55311276f08f9224a74a62dcb4708bd7439e2a03911 # ratchet:postgres:18.3-alpine
         env:
           POSTGRES_PASSWORD: postgres
         ports:
@@ -221,17 +221,17 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       wiremock:
-        image: wiremock/wiremock:3.13.2-alpine
+        image: index.docker.io/wiremock/wiremock@sha256:53dd996e0625bbaa906102d21fbfe029a209e92fd33862f73b3885a386e5db57 # ratchet:wiremock/wiremock:3.13.2-alpine
         ports:
           - '9000:8080'
         options: --name wiremock
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           submodules: true
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5
         with:
           cache: maven
           distribution: 'temurin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # ratchet:googleapis/release-please-action@v4
         with:
           release-type: maven
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/dev/snow-white.json
+++ b/dev/snow-white.json
@@ -1,12 +1,6 @@
 {
-  "apiInformation": [
-    {
-      "serviceName": "example-application",
-      "apiName": "ping-pong",
-      "apiVersion": "1.0.0"
-    }
-  ],
   "apiNamePath": "info.x-api-name",
+  "apiSpecs": "example-application/specs/*.yml",
   "qualityGate": "basic-coverage",
   "url": "http://localhost:9000"
 }

--- a/example-application/pom.xml
+++ b/example-application/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>io.github.bbortt.snow-white</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0.0-SNAPSHOT-alpha.12</version>
+    <version>1.0.0-SNAPSHOT-alpha.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/helm/charts/snow-white/Chart.lock
+++ b/helm/charts/snow-white/Chart.lock
@@ -11,5 +11,5 @@ dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.38.0
-digest: sha256:9854100f86b65d33634a0e1f5b839330d72879eb28ef4ef6cf4b2562b6ec7c1c
-generated: "2026-04-13T18:02:01.846383028Z"
+digest: sha256:34b75f88a959a09dfb36fc4eeaff5ff2cb41b5dfa9321d7a888fb8816f502c5c
+generated: "2026-04-13T21:50:10.7474791+02:00"

--- a/helm/charts/snow-white/Chart.yaml
+++ b/helm/charts/snow-white/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
   - name: kafka-ui
     version: 1.6.2
     repository: 'https://kafbat.github.io/helm-charts'
-    condition: kafkaui.enabled
+    condition: kafka-ui.enabled
   - name: postgresql
     version: 18.5.17
     repository: 'https://charts.bitnami.com/bitnami'

--- a/helm/charts/snow-white/README.md
+++ b/helm/charts/snow-white/README.md
@@ -80,6 +80,7 @@ A Helm chart for deploying [`snow-white`](https://github.com/bbortt/snow-white).
 
 | Key                            | Type   | Default                    | Description                                                        |
 | ------------------------------ | ------ | -------------------------- | ------------------------------------------------------------------ |
+| kafka-ui.enabled               | bool   | `false`                    | Install kafbat/kafka-ui alongside Snow-White for debugging.        |
 | kafka.clusterId                | string | `"NmE4MjRhYjI1MjkwNGI5ZG"` | Kafka cluster ID. Run "kafka-storage random-uuid" to generate one. |
 | kafka.enabled                  | bool   | `true`                     | Deploy Kafka StatefulSet alongside Snow-White.                     |
 | kafka.image.name               | string | `"confluentinc/cp-kafka"`  | Image name.                                                        |
@@ -87,7 +88,6 @@ A Helm chart for deploying [`snow-white`](https://github.com/bbortt/snow-white).
 | kafka.image.tag                | string | `"8.2.0"`                  | Image tag.                                                         |
 | kafka.persistence.size         | string | `"10Gi"`                   | Size of the storage for Kafka.                                     |
 | kafka.persistence.storageClass | string | `"hostpath"`               | Storage class for Kafka persistent volumes.                        |
-| kafkaui.enabled                | bool   | `false`                    | Install kafbat/kafka-ui alongside Snow-White for debugging.        |
 
 ### Infrastructure (PostgreSQL)
 
@@ -206,6 +206,7 @@ A Helm chart for deploying [`snow-white`](https://github.com/bbortt/snow-white).
 | Key                                                            | Type   | Default                                    | Description |
 | -------------------------------------------------------------- | ------ | ------------------------------------------ | ----------- |
 | influxdb2.pdb.create                                           | bool   | `false`                                    |             |
+| kafka-ui.yamlApplicationConfigConfigMap.name                   | string | `"kafbat-ui-configmap"`                    |             |
 | postgresql.architecture                                        | string | `"standalone"`                             |             |
 | postgresql.primary.extraEnvVars[0].name                        | string | `"API_INDEX_DATASOURCE_PASSWORD"`          |             |
 | postgresql.primary.extraEnvVars[0].valueFrom.secretKeyRef.key  | string | `"api-index-password"`                     |             |

--- a/helm/charts/snow-white/templates/kafka-ui.yaml
+++ b/helm/charts/snow-white/templates/kafka-ui.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kafkaui.enabled }}
+{{- if (index .Values "kafka-ui").enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/charts/snow-white/values.yaml
+++ b/helm/charts/snow-white/values.yaml
@@ -302,10 +302,12 @@ kafka:
     # @section -- Infrastructure (Kafka)
     size: 10Gi
 
-kafkaui:
+kafka-ui:
   # -- Install kafbat/kafka-ui alongside Snow-White for debugging.
   # @section -- Infrastructure (Kafka)
   enabled: false
+  yamlApplicationConfigConfigMap:
+    name: kafbat-ui-configmap
 
 otelCollector:
   image:

--- a/helm/pom.xml
+++ b/helm/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>io.github.bbortt.snow-white</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0.0-SNAPSHOT-alpha.12</version>
+    <version>1.0.0-SNAPSHOT-alpha.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/helm/test/kafka-ui.spec.ts
+++ b/helm/test/kafka-ui.spec.ts
@@ -30,7 +30,7 @@ describe('Kafka UI', () => {
     const manifests = await renderHelmChart({
       chartPath: 'charts/snow-white',
       values: {
-        kafkaui: {
+        ['kafka-ui']: {
           enabled: true,
         },
       },
@@ -60,7 +60,7 @@ describe('Kafka UI', () => {
     const manifests = await renderHelmChart({
       chartPath: 'charts/snow-white',
       values: {
-        kafkaui: {
+        ['kafka-ui']: {
           enabled: true,
         },
       },
@@ -75,12 +75,86 @@ describe('Kafka UI', () => {
     expect(configMap).toBeDefined();
   });
 
+  const renderAndGetKafkaUiContainer = async (
+    manifests?: any[],
+  ): Promise<any> => {
+    if (!manifests) {
+      manifests = await renderHelmChart({
+        chartPath: 'charts/snow-white',
+        values: {
+          ['kafka-ui']: {
+            enabled: true,
+          },
+        },
+      });
+    }
+
+    const deployment = manifests.find(
+      (m) =>
+        m.kind === 'Deployment' &&
+        m.metadata.name.startsWith('test-release-kafka-ui'),
+    );
+
+    const { spec } = deployment;
+    expect(spec).toBeDefined();
+
+    const { template } = spec;
+    expect(template).toBeDefined();
+
+    const templateSpec = template.spec;
+    expect(templateSpec).toBeDefined();
+
+    const { containers, volumes } = templateSpec;
+    expect(containers).toBeDefined();
+    expect(containers).toHaveLength(1);
+
+    const kafkaUiContainer = containers[0];
+    return { kafkaUiContainer, volumes };
+  };
+
+  it('should mount configmap to container when enabled', async () => {
+    const manifests = await renderHelmChart({
+      chartPath: 'charts/snow-white',
+      values: {
+        ['kafka-ui']: {
+          enabled: true,
+        },
+      },
+    });
+
+    const { kafkaUiContainer, volumes } =
+      await renderAndGetKafkaUiContainer(manifests);
+
+    expect(kafkaUiContainer.volumeMounts).toHaveLength(1);
+    expect(kafkaUiContainer.volumeMounts[0].mountPath).toBe('/kafka-ui/');
+
+    expect(volumes).toHaveLength(1);
+    expect(volumes[0].name).toBe(kafkaUiContainer.volumeMounts[0].name);
+
+    const configMap = manifests.find(
+      (m) =>
+        m.kind === 'ConfigMap' && m.metadata.name === volumes[0].configMap.name,
+    );
+
+    expect(configMap).toBeDefined();
+  });
+
+  it('should configure spring properties with configmap location when enabled', async () => {
+    const { kafkaUiContainer } = await renderAndGetKafkaUiContainer();
+
+    const additionalConfigLocation = kafkaUiContainer.env.find(
+      (env) => env.name === 'SPRING_CONFIG_ADDITIONAL-LOCATION',
+    );
+
+    expect(additionalConfigLocation.value).toBe('/kafka-ui/config.yml');
+  });
+
   describe('ConfigMap', () => {
     const renderAndGetConfigMap = async (): any => {
       const manifests = await renderHelmChart({
         chartPath: 'charts/snow-white',
         values: {
-          kafkaui: {
+          ['kafka-ui']: {
             enabled: true,
           },
         },

--- a/internal/archunit-rules/pom.xml
+++ b/internal/archunit-rules/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>io.github.bbortt.snow-white</groupId>
     <artifactId>internal</artifactId>
-    <version>1.0.0-SNAPSHOT-alpha.12</version>
+    <version>1.0.0-SNAPSHOT-alpha.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/internal/commons/pom.xml
+++ b/internal/commons/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>io.github.bbortt.snow-white</groupId>
     <artifactId>internal</artifactId>
-    <version>1.0.0-SNAPSHOT-alpha.12</version>
+    <version>1.0.0-SNAPSHOT-alpha.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/internal/pom.xml
+++ b/internal/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>io.github.bbortt.snow-white</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0.0-SNAPSHOT-alpha.12</version>
+    <version>1.0.0-SNAPSHOT-alpha.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/microservices/api-gateway/pom.xml
+++ b/microservices/api-gateway/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>io.github.bbortt.snow-white.microservices</groupId>
     <artifactId>microservices</artifactId>
-    <version>1.0.0-SNAPSHOT-alpha.12</version>
+    <version>1.0.0-SNAPSHOT-alpha.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/microservices/api-index-api/pom.xml
+++ b/microservices/api-index-api/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>io.github.bbortt.snow-white.microservices</groupId>
     <artifactId>microservices</artifactId>
-    <version>1.0.0-SNAPSHOT-alpha.12</version>
+    <version>1.0.0-SNAPSHOT-alpha.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/microservices/api-sync-job/pom.xml
+++ b/microservices/api-sync-job/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>io.github.bbortt.snow-white.microservices</groupId>
     <artifactId>microservices</artifactId>
-    <version>1.0.0-SNAPSHOT-alpha.12</version>
+    <version>1.0.0-SNAPSHOT-alpha.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/microservices/openapi-coverage-stream/pom.xml
+++ b/microservices/openapi-coverage-stream/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>io.github.bbortt.snow-white.microservices</groupId>
     <artifactId>microservices</artifactId>
-    <version>1.0.0-SNAPSHOT-alpha.12</version>
+    <version>1.0.0-SNAPSHOT-alpha.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/ParameterCoverageCalculator.java
+++ b/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/ParameterCoverageCalculator.java
@@ -155,7 +155,7 @@ public class ParameterCoverageCalculator
     String paramIn,
     String operationKey
   ) {
-    if (isNull(data.attributes())) {
+    if (isNull(data.attributes()) || isNull(paramIn)) {
       return false;
     }
 

--- a/microservices/openapi-coverage-stream/src/test/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/ParameterCoverageCalculatorTest.java
+++ b/microservices/openapi-coverage-stream/src/test/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/ParameterCoverageCalculatorTest.java
@@ -277,6 +277,33 @@ class ParameterCoverageCalculatorTest {
     }
 
     @Test
+    void shouldNotThrow_whenParameterHasNullIn() {
+      var parameter = new Parameter();
+      parameter.setName("someParam");
+      // in is intentionally left null to reproduce the NPE scenario
+
+      var operation = new Operation();
+      operation.setParameters(List.of(parameter));
+
+      var pathToOpenAPIOperationMap = Map.of("GET_/api/v1/users", operation);
+
+      var pathToTelemetryMap = createTelemetryWithQueryParams(
+        Map.of("GET_/api/v1/users", "someParam=value")
+      );
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r -> assertThat(r.openApiCriteria()).isEqualTo(PARAMETER_COVERAGE),
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(0.0)),
+        r -> assertThat(r.additionalInformation()).isNotNull()
+      );
+    }
+
+    @Test
     void shouldHandleOperationWithNullParameters() {
       var operation = new Operation();
       operation.setParameters(null);

--- a/microservices/otel-event-filter-stream/pom.xml
+++ b/microservices/otel-event-filter-stream/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>io.github.bbortt.snow-white.microservices</groupId>
     <artifactId>microservices</artifactId>
-    <version>1.0.0-SNAPSHOT-alpha.12</version>
+    <version>1.0.0-SNAPSHOT-alpha.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/microservices/pom.xml
+++ b/microservices/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>io.github.bbortt.snow-white</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0.0-SNAPSHOT-alpha.12</version>
+    <version>1.0.0-SNAPSHOT-alpha.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/microservices/quality-gate-api/pom.xml
+++ b/microservices/quality-gate-api/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>io.github.bbortt.snow-white.microservices</groupId>
     <artifactId>microservices</artifactId>
-    <version>1.0.0-SNAPSHOT-alpha.12</version>
+    <version>1.0.0-SNAPSHOT-alpha.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/microservices/report-coordinator-api/pom.xml
+++ b/microservices/report-coordinator-api/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>io.github.bbortt.snow-white.microservices</groupId>
     <artifactId>microservices</artifactId>
-    <version>1.0.0-SNAPSHOT-alpha.12</version>
+    <version>1.0.0-SNAPSHOT-alpha.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>io.github.bbortt.snow-white</groupId>
   <artifactId>parent</artifactId>
-  <version>1.0.0-SNAPSHOT-alpha.12</version>
+  <version>1.0.0-SNAPSHOT-alpha.13</version>
 
   <packaging>pom</packaging>
 

--- a/toolkit/annotation-api/pom.xml
+++ b/toolkit/annotation-api/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>io.github.bbortt.snow-white.toolkit</groupId>
     <artifactId>toolkit</artifactId>
-    <version>1.0.0-SNAPSHOT-alpha.12</version>
+    <version>1.0.0-SNAPSHOT-alpha.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/toolkit/cli/bun.lock
+++ b/toolkit/cli/bun.lock
@@ -1,6 +1,6 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
+  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "snow-white",
@@ -50,7 +50,7 @@
     },
   },
   "packages": {
-    "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
@@ -66,17 +66,17 @@
 
     "@eslint/compat": ["@eslint/compat@2.0.5", "", { "dependencies": { "@eslint/core": "^1.2.1" }, "peerDependencies": { "eslint": "^8.40 || 9 || 10" }, "optionalPeers": ["eslint"] }, "sha512-IbHDbHJfkVNv6xjlET8AIVo/K1NQt7YT4Rp6ok/clyBGcpRx1l6gv0Rq3vBvYfPJIZt6ODf66Zq08FJNDpnzgg=="],
 
-    "@eslint/config-array": ["@eslint/config-array@0.23.4", "", { "dependencies": { "@eslint/object-schema": "^3.0.4", "debug": "^4.3.1", "minimatch": "^10.2.4" } }, "sha512-lf19F24LSMfF8weXvW5QEtnLqW70u7kgit5e9PSx0MsHAFclGd1T9ynvWEMDT1w5J4Qt54tomGeAhdoAku1Xow=="],
+    "@eslint/config-array": ["@eslint/config-array@0.23.5", "", { "dependencies": { "@eslint/object-schema": "^3.0.5", "debug": "^4.3.1", "minimatch": "^10.2.4" } }, "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA=="],
 
-    "@eslint/config-helpers": ["@eslint/config-helpers@0.5.4", "", { "dependencies": { "@eslint/core": "^1.2.0" } }, "sha512-jJhqiY3wPMlWWO3370M86CPJ7pt8GmEwSLglMfQhjXal07RCvhmU0as4IuUEW5SJeunfItiEetHmSxCCe9lDBg=="],
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.5.5", "", { "dependencies": { "@eslint/core": "^1.2.1" } }, "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w=="],
 
-    "@eslint/core": ["@eslint/core@1.2.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-8FTGbNzTvmSlc4cZBaShkC6YvFMG0riksYWRFKXztqVdXaQbcZLXlFbSpC05s70sGEsXAw0qwhx69JiW7hQS7A=="],
+    "@eslint/core": ["@eslint/core@1.2.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ=="],
 
     "@eslint/js": ["@eslint/js@10.0.1", "", { "peerDependencies": { "eslint": "^10.0.0" }, "optionalPeers": ["eslint"] }, "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA=="],
 
-    "@eslint/object-schema": ["@eslint/object-schema@3.0.4", "", {}, "sha512-55lO/7+Yp0ISKRP0PsPtNTeNGapXaO085aELZmWCVc5SH3jfrqpuU6YgOdIxMS99ZHkQN1cXKE+cdIqwww9ptw=="],
+    "@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
 
-    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.0", "", { "dependencies": { "@eslint/core": "^1.2.0", "levn": "^0.4.1" } }, "sha512-ejvBr8MQCbVsWNZnCwDXjUKq40MDmHalq7cJ6e9s/qzTUFIIo/afzt1Vui9T97FM/V/pN4YsFVoed5NIa96RDg=="],
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.1", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ=="],
 
     "@hapi/address": ["@hapi/address@5.1.1", "", { "dependencies": { "@hapi/hoek": "^11.0.2" } }, "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA=="],
 
@@ -86,29 +86,27 @@
 
     "@hapi/pinpoint": ["@hapi/pinpoint@2.0.1", "", {}, "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q=="],
 
-    "@hapi/tlds": ["@hapi/tlds@1.1.3", "", {}, "sha512-QIvUMB5VZ8HMLZF9A2oWr3AFM430QC8oGd0L35y2jHpuW6bIIca6x/xL7zUf4J7L9WJ3qjz+iJII8ncaeMbpSg=="],
+    "@hapi/tlds": ["@hapi/tlds@1.1.6", "", {}, "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw=="],
 
     "@hapi/topo": ["@hapi/topo@6.0.2", "", { "dependencies": { "@hapi/hoek": "^11.0.2" } }, "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
-    "@humanfs/node": ["@humanfs/node@0.16.6", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.3.0" } }, "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw=="],
+    "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
 
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
-    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.8", "", { "dependencies": { "@jridgewell/set-array": "^1.2.1", "@jridgewell/sourcemap-codec": "^1.4.10", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA=="],
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
 
-    "@jridgewell/set-array": ["@jridgewell/set-array@1.2.1", "", {}, "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A=="],
+    "@jridgewell/source-map": ["@jridgewell/source-map@0.3.11", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.25" } }, "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA=="],
 
-    "@jridgewell/source-map": ["@jridgewell/source-map@0.3.6", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.25" } }, "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ=="],
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
-
-    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
 
@@ -138,25 +136,25 @@
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
-    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.54.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.54.0", "@typescript-eslint/type-utils": "8.54.0", "@typescript-eslint/utils": "8.54.0", "@typescript-eslint/visitor-keys": "8.54.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.54.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ=="],
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.58.2", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.58.2", "@typescript-eslint/type-utils": "8.58.2", "@typescript-eslint/utils": "8.58.2", "@typescript-eslint/visitor-keys": "8.58.2", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.58.2", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw=="],
 
     "@typescript-eslint/parser": ["@typescript-eslint/parser@8.58.2", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.58.2", "@typescript-eslint/types": "8.58.2", "@typescript-eslint/typescript-estree": "8.58.2", "@typescript-eslint/visitor-keys": "8.58.2", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg=="],
 
     "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.58.2", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.58.2", "@typescript-eslint/types": "^8.58.2", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg=="],
 
-    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.58.1", "", { "dependencies": { "@typescript-eslint/types": "8.58.1", "@typescript-eslint/visitor-keys": "8.58.1" } }, "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w=="],
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.58.2", "", { "dependencies": { "@typescript-eslint/types": "8.58.2", "@typescript-eslint/visitor-keys": "8.58.2" } }, "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q=="],
 
     "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.58.2", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A=="],
 
-    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.54.0", "", { "dependencies": { "@typescript-eslint/types": "8.54.0", "@typescript-eslint/typescript-estree": "8.54.0", "@typescript-eslint/utils": "8.54.0", "debug": "^4.4.3", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-hiLguxJWHjjwL6xMBwD903ciAwd7DmK30Y9Axs/etOkftC3ZNN9K44IuRD/EB08amu+Zw6W37x9RecLkOo3pMA=="],
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.58.2", "", { "dependencies": { "@typescript-eslint/types": "8.58.2", "@typescript-eslint/typescript-estree": "8.58.2", "@typescript-eslint/utils": "8.58.2", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg=="],
 
-    "@typescript-eslint/types": ["@typescript-eslint/types@8.58.1", "", {}, "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw=="],
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.58.2", "", {}, "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ=="],
 
     "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.58.2", "", { "dependencies": { "@typescript-eslint/project-service": "8.58.2", "@typescript-eslint/tsconfig-utils": "8.58.2", "@typescript-eslint/types": "8.58.2", "@typescript-eslint/visitor-keys": "8.58.2", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw=="],
 
-    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.58.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.58.1", "@typescript-eslint/types": "8.58.1", "@typescript-eslint/typescript-estree": "8.58.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ=="],
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.58.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.58.2", "@typescript-eslint/types": "8.58.2", "@typescript-eslint/typescript-estree": "8.58.2" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA=="],
 
-    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.1", "", { "dependencies": { "@typescript-eslint/types": "8.58.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ=="],
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.2", "", { "dependencies": { "@typescript-eslint/types": "8.58.2", "eslint-visitor-keys": "^5.0.0" } }, "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA=="],
 
     "@vitest/eslint-plugin": ["@vitest/eslint-plugin@1.6.15", "", { "dependencies": { "@typescript-eslint/scope-manager": "^8.58.0", "@typescript-eslint/utils": "^8.58.0" }, "peerDependencies": { "@typescript-eslint/eslint-plugin": "*", "eslint": ">=8.57.0", "typescript": ">=5.0.0", "vitest": "*" }, "optionalPeers": ["@typescript-eslint/eslint-plugin", "typescript", "vitest"] }, "sha512-dTMjrdngmcB+DxomlKQ+SUubCTvd0m2hQQFpv5sx+GRodmeoxr2PVbphk57SVp250vpxphk9Ccwyv6fQ6+2gkA=="],
 
@@ -198,6 +196,8 @@
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
+    "acorn-import-phases": ["acorn-import-phases@1.0.4", "", { "peerDependencies": { "acorn": "^8.14.0" } }, "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ=="],
+
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
@@ -206,7 +206,7 @@
 
     "ajv-keywords": ["ajv-keywords@5.1.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3" }, "peerDependencies": { "ajv": "^8.8.2" } }, "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw=="],
 
-    "ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "are-docs-informative": ["are-docs-informative@0.0.2", "", {}, "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig=="],
 
@@ -234,9 +234,9 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.14", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-fOVLPAsFTsQfuCkvahZkzq6nf8KvGWanlYoTh0SVA0A/PIUxQGU2AOZAoD95n2gFLVDW/jP6sbGLny95nmEuHA=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.18", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A=="],
 
-    "brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
+    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -244,11 +244,11 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
-    "builtin-modules": ["builtin-modules@5.0.0", "", {}, "sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg=="],
+    "builtin-modules": ["builtin-modules@5.1.0", "", {}, "sha512-c5JxaDrzwRjq3WyJkI1AGR5xy6Gr6udlt7sQPbl09+3ckB+Zo2qqQ2KhCTBr7Q8dHB43bENGYEk4xddrFH/b7A=="],
 
     "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
-    "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
+    "call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
@@ -256,7 +256,7 @@
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
-    "caniuse-lite": ["caniuse-lite@1.0.30001784", "", {}, "sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw=="],
+    "caniuse-lite": ["caniuse-lite@1.0.30001787", "", {}, "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -308,21 +308,21 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.331", "", {}, "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.335", "", {}, "sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q=="],
 
-    "enhanced-resolve": ["enhanced-resolve@5.18.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg=="],
+    "enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
-    "error-ex": ["error-ex@1.3.2", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g=="],
+    "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
-    "es-abstract": ["es-abstract@1.24.0", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg=="],
+    "es-abstract": ["es-abstract@1.24.2", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
-    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+    "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
@@ -342,7 +342,7 @@
 
     "eslint-config-prettier": ["eslint-config-prettier@10.1.8", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w=="],
 
-    "eslint-import-resolver-node": ["eslint-import-resolver-node@0.3.9", "", { "dependencies": { "debug": "^3.2.7", "is-core-module": "^2.13.0", "resolve": "^1.22.4" } }, "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g=="],
+    "eslint-import-resolver-node": ["eslint-import-resolver-node@0.3.10", "", { "dependencies": { "debug": "^3.2.7", "is-core-module": "^2.16.1", "resolve": "^2.0.0-next.6" } }, "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ=="],
 
     "eslint-module-utils": ["eslint-module-utils@2.12.1", "", { "dependencies": { "debug": "^3.2.7" } }, "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw=="],
 
@@ -396,7 +396,7 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
-    "fast-uri": ["fast-uri@3.0.6", "", {}, "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw=="],
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -410,9 +410,9 @@
 
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
-    "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
-    "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
+    "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
@@ -424,15 +424,17 @@
 
     "functions-have-names": ["functions-have-names@1.2.3", "", {}, "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="],
 
+    "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
+
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-symbol-description": ["get-symbol-description@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6" } }, "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg=="],
 
-    "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
+    "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
 
-    "git-hooks-list": ["git-hooks-list@4.1.1", "", {}, "sha512-cmP497iLq54AZnv4YRAEMnEyQ1eIn4tGKbmswqwmFV4GBnAqE8NLtWxxdXa++AalfgL5EBH4IxTPyquEuGY/jA=="],
+    "git-hooks-list": ["git-hooks-list@4.2.1", "", {}, "sha512-WNvqJjOxxs/8ZP9+DWdwWJ7cDsd60NHf39XnD82pDVrKO5q7xfPqpkK6hwEAmBa/ZSEE4IOoR75EzbbIuwGlMw=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -498,7 +500,7 @@
 
     "is-finalizationregistry": ["is-finalizationregistry@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg=="],
 
-    "is-generator-function": ["is-generator-function@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "get-proto": "^1.0.0", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ=="],
+    "is-generator-function": ["is-generator-function@1.1.2", "", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
@@ -532,7 +534,7 @@
 
     "isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
-    "isexe": ["isexe@3.1.1", "", {}, "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ=="],
+    "isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
 
     "jest-worker": ["jest-worker@27.5.1", "", { "dependencies": { "@types/node": "*", "merge-stream": "^2.0.0", "supports-color": "^8.0.0" } }, "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg=="],
 
@@ -542,7 +544,7 @@
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
-    "jsdoc-type-pratt-parser": ["jsdoc-type-pratt-parser@7.1.1", "", {}, "sha512-/2uqY7x6bsrpi3i9LVU6J89352C0rpMk0as8trXxCtvd4kPk1ke/Eyif6wqfSLvoNJqcDG9Vk4UsXgygzCt2xA=="],
+    "jsdoc-type-pratt-parser": ["jsdoc-type-pratt-parser@7.2.0", "", {}, "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -562,7 +564,7 @@
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
-    "loader-runner": ["loader-runner@4.3.0", "", {}, "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg=="],
+    "loader-runner": ["loader-runner@4.3.1", "", {}, "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
@@ -580,7 +582,7 @@
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
-    "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
@@ -592,11 +594,13 @@
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
+    "node-exports-info": ["node-exports-info@1.6.0", "", { "dependencies": { "array.prototype.flatmap": "^1.3.3", "es-errors": "^1.3.0", "object.entries": "^1.1.9", "semver": "^6.3.1" } }, "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw=="],
+
     "node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
-    "npm-check-updates": ["npm-check-updates@20.0.1", "", { "bin": { "npm-check-updates": "build/cli.js", "ncu": "build/cli.js" } }, "sha512-YuzpyL1Od5dJzpeETVh2H5o1I8tpi0zkf6v7k7rXwUDfiDliBX9dgVIb7FlEfp8Lu2RtECAv63ZHm/rqpIhYsw=="],
+    "npm-check-updates": ["npm-check-updates@20.0.1", "", { "bin": { "ncu": "build/cli.js", "npm-check-updates": "build/cli.js" } }, "sha512-YuzpyL1Od5dJzpeETVh2H5o1I8tpi0zkf6v7k7rXwUDfiDliBX9dgVIb7FlEfp8Lu2RtECAv63ZHm/rqpIhYsw=="],
 
     "npm-java-runner": ["npm-java-runner@2.0.0", "", {}, "sha512-vYkU45l0J6rNoXJdHHSPzmW9mpbBDR/RmO0w60tnJOmlW3Tki6J9lNK/OQq8EQZSsBe1U3NL9TgJKWL+2YeXxw=="],
 
@@ -611,6 +615,8 @@
     "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
 
     "object.assign": ["object.assign@4.1.7", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0", "has-symbols": "^1.1.0", "object-keys": "^1.1.1" } }, "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw=="],
+
+    "object.entries": ["object.entries@1.1.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-object-atoms": "^1.1.1" } }, "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw=="],
 
     "object.fromentries": ["object.fromentries@2.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.2", "es-object-atoms": "^1.0.0" } }, "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ=="],
 
@@ -642,7 +648,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "pidtree": ["pidtree@0.6.0", "", { "bin": { "pidtree": "bin/pidtree.js" } }, "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g=="],
 
@@ -662,8 +668,6 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "randombytes": ["randombytes@2.1.0", "", { "dependencies": { "safe-buffer": "^5.1.0" } }, "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ=="],
-
     "read-package-json-fast": ["read-package-json-fast@4.0.0", "", { "dependencies": { "json-parse-even-better-errors": "^4.0.0", "npm-normalize-package-bin": "^4.0.0" } }, "sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg=="],
 
     "refa": ["refa@0.12.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0" } }, "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g=="],
@@ -678,13 +682,13 @@
 
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
 
-    "regjsparser": ["regjsparser@0.13.0", "", { "dependencies": { "jsesc": "~3.1.0" }, "bin": { "regjsparser": "bin/parser" } }, "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q=="],
+    "regjsparser": ["regjsparser@0.13.1", "", { "dependencies": { "jsesc": "~3.1.0" }, "bin": { "regjsparser": "bin/parser" } }, "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
-    "reserved-identifiers": ["reserved-identifiers@1.0.0", "", {}, "sha512-h0bP2Katmvf3hv4Z3WtDl4+6xt/OglQ2Xa6TnhZ/Rm9/7IH1crXQqMwD4J2ngKBonVv+fB55zfGgNDAmsevLVQ=="],
+    "reserved-identifiers": ["reserved-identifiers@1.2.0", "", {}, "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw=="],
 
-    "resolve": ["resolve@1.22.10", "", { "dependencies": { "is-core-module": "^2.16.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w=="],
+    "resolve": ["resolve@2.0.0-next.6", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "node-exports-info": "^1.6.0", "object-keys": "^1.1.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -693,8 +697,6 @@
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
     "safe-array-concat": ["safe-array-concat@1.1.3", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q=="],
-
-    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safe-push-apply": ["safe-push-apply@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "isarray": "^2.0.5" } }, "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA=="],
 
@@ -705,8 +707,6 @@
     "scslre": ["scslre@0.3.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0", "refa": "^0.12.0", "regexp-ast-analysis": "^0.7.0" } }, "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "serialize-javascript": ["serialize-javascript@6.0.2", "", { "dependencies": { "randombytes": "^2.1.0" } }, "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
@@ -722,15 +722,15 @@
 
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
-    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
 
     "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
-    "sort-object-keys": ["sort-object-keys@2.0.1", "", {}, "sha512-R89fO+z3x7hiKPXX5P0qim+ge6Y60AjtlW+QQpRozrrNcR1lw9Pkpm5MLB56HoNvdcLHL4wbpq16OcvGpEDJIg=="],
+    "sort-object-keys": ["sort-object-keys@2.1.0", "", {}, "sha512-SOiEnthkJKPv2L6ec6HMwhUcN0/lppkeYuN1x63PbyPRrgSPIuBJCiYxYyvWRTtjMlOi14vQUCGUJqS6PLVm8g=="],
 
-    "sort-package-json": ["sort-package-json@3.6.0", "", { "dependencies": { "detect-indent": "^7.0.2", "detect-newline": "^4.0.1", "git-hooks-list": "^4.1.1", "is-plain-obj": "^4.1.0", "semver": "^7.7.3", "sort-object-keys": "^2.0.1", "tinyglobby": "^0.2.15" }, "bin": { "sort-package-json": "cli.js" } }, "sha512-fyJsPLhWvY7u2KsKPZn1PixbXp+1m7V8NWqU8CvgFRbMEX41Ffw1kD8n0CfJiGoaSfoAvbrqRRl/DcHO8omQOQ=="],
+    "sort-package-json": ["sort-package-json@3.6.1", "", { "dependencies": { "detect-indent": "^7.0.2", "detect-newline": "^4.0.1", "git-hooks-list": "^4.1.1", "is-plain-obj": "^4.1.0", "semver": "^7.7.3", "sort-object-keys": "^2.0.1", "tinyglobby": "^0.2.15" }, "bin": { "sort-package-json": "cli.js" } }, "sha512-Chgejw1+10p2D0U2tB7au1lHtz6TkFnxmvZktyBCRyV0GgmF6nl1IxXxAsPtJVsUyg/fo+BfCMAVVFUVRkAHrQ=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -740,7 +740,7 @@
 
     "spdx-expression-parse": ["spdx-expression-parse@4.0.0", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ=="],
 
-    "spdx-license-ids": ["spdx-license-ids@3.0.21", "", {}, "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg=="],
+    "spdx-license-ids": ["spdx-license-ids@3.0.23", "", {}, "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
@@ -760,19 +760,19 @@
 
     "synckit": ["synckit@0.11.12", "", { "dependencies": { "@pkgr/core": "^0.2.9" } }, "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ=="],
 
-    "tapable": ["tapable@2.2.2", "", {}, "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg=="],
+    "tapable": ["tapable@2.3.2", "", {}, "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA=="],
 
-    "terser": ["terser@5.43.1", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.14.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": { "terser": "bin/terser" } }, "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg=="],
+    "terser": ["terser@5.46.1", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.15.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": { "terser": "bin/terser" } }, "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ=="],
 
-    "terser-webpack-plugin": ["terser-webpack-plugin@5.3.14", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "jest-worker": "^27.4.5", "schema-utils": "^4.3.0", "serialize-javascript": "^6.0.2", "terser": "^5.31.1" }, "peerDependencies": { "webpack": "^5.1.0" } }, "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw=="],
+    "terser-webpack-plugin": ["terser-webpack-plugin@5.4.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "jest-worker": "^27.4.5", "schema-utils": "^4.3.0", "terser": "^5.31.1" }, "peerDependencies": { "webpack": "^5.1.0" } }, "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g=="],
 
-    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "to-valid-identifier": ["to-valid-identifier@1.0.0", "", { "dependencies": { "@sindresorhus/base62": "^1.0.0", "reserved-identifiers": "^1.0.0" } }, "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw=="],
 
-    "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
     "ts-declaration-location": ["ts-declaration-location@1.0.7", "", { "dependencies": { "picomatch": "^4.0.2" }, "peerDependencies": { "typescript": ">=4.0.0" } }, "sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA=="],
 
@@ -806,11 +806,11 @@
 
     "wait-on": ["wait-on@9.0.5", "", { "dependencies": { "axios": "^1.15.0", "joi": "^18.1.2", "lodash": "^4.18.1", "minimist": "^1.2.8", "rxjs": "^7.8.2" }, "bin": { "wait-on": "bin/wait-on" } }, "sha512-qgnbHDfDTRIp73ANEJNRW/7kn8CrDUcvZz18xotJQku/P4saTGkbIzvnMZebPmVvVNUiRq1qWAPyqCH+W4H8KA=="],
 
-    "watchpack": ["watchpack@2.4.4", "", { "dependencies": { "glob-to-regexp": "^0.4.1", "graceful-fs": "^4.1.2" } }, "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA=="],
+    "watchpack": ["watchpack@2.5.1", "", { "dependencies": { "glob-to-regexp": "^0.4.1", "graceful-fs": "^4.1.2" } }, "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg=="],
 
-    "webpack": ["webpack@5.99.9", "", { "dependencies": { "@types/eslint-scope": "^3.7.7", "@types/estree": "^1.0.6", "@types/json-schema": "^7.0.15", "@webassemblyjs/ast": "^1.14.1", "@webassemblyjs/wasm-edit": "^1.14.1", "@webassemblyjs/wasm-parser": "^1.14.1", "acorn": "^8.14.0", "browserslist": "^4.24.0", "chrome-trace-event": "^1.0.2", "enhanced-resolve": "^5.17.1", "es-module-lexer": "^1.2.1", "eslint-scope": "5.1.1", "events": "^3.2.0", "glob-to-regexp": "^0.4.1", "graceful-fs": "^4.2.11", "json-parse-even-better-errors": "^2.3.1", "loader-runner": "^4.2.0", "mime-types": "^2.1.27", "neo-async": "^2.6.2", "schema-utils": "^4.3.2", "tapable": "^2.1.1", "terser-webpack-plugin": "^5.3.11", "watchpack": "^2.4.1", "webpack-sources": "^3.2.3" }, "bin": { "webpack": "bin/webpack.js" } }, "sha512-brOPwM3JnmOa+7kd3NsmOUOwbDAj8FT9xDsG3IW0MgbN9yZV7Oi/s/+MNQ/EcSMqw7qfoRyXPoeEWT8zLVdVGg=="],
+    "webpack": ["webpack@5.106.1", "", { "dependencies": { "@types/eslint-scope": "^3.7.7", "@types/estree": "^1.0.8", "@types/json-schema": "^7.0.15", "@webassemblyjs/ast": "^1.14.1", "@webassemblyjs/wasm-edit": "^1.14.1", "@webassemblyjs/wasm-parser": "^1.14.1", "acorn": "^8.16.0", "acorn-import-phases": "^1.0.3", "browserslist": "^4.28.1", "chrome-trace-event": "^1.0.2", "enhanced-resolve": "^5.20.0", "es-module-lexer": "^2.0.0", "eslint-scope": "5.1.1", "events": "^3.2.0", "glob-to-regexp": "^0.4.1", "graceful-fs": "^4.2.11", "json-parse-even-better-errors": "^2.3.1", "loader-runner": "^4.3.1", "mime-types": "^2.1.27", "neo-async": "^2.6.2", "schema-utils": "^4.3.3", "tapable": "^2.3.0", "terser-webpack-plugin": "^5.3.17", "watchpack": "^2.5.1", "webpack-sources": "^3.3.4" }, "bin": { "webpack": "bin/webpack.js" } }, "sha512-EW8af29ak8Oaf4T8k8YsajjrDBDYgnKZ5er6ljWFJsXABfTNowQfvHLftwcepVgdz+IoLSdEAbBiM9DFXoll9w=="],
 
-    "webpack-sources": ["webpack-sources@3.3.3", "", {}, "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg=="],
+    "webpack-sources": ["webpack-sources@3.3.4", "", {}, "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q=="],
 
     "which": ["which@5.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ=="],
 
@@ -820,7 +820,7 @@
 
     "which-collection": ["which-collection@1.0.2", "", { "dependencies": { "is-map": "^2.0.3", "is-set": "^2.0.3", "is-weakmap": "^2.0.2", "is-weakset": "^2.0.3" } }, "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw=="],
 
-    "which-typed-array": ["which-typed-array@1.1.19", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw=="],
+    "which-typed-array": ["which-typed-array@1.1.20", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg=="],
 
     "wiremock": ["wiremock@3.13.2", "", { "dependencies": { "npm-java-runner": "^2.0.0" }, "bin": { "wiremock": "index.js" } }, "sha512-YkqP6qQhVS45/SjG1sz5rQXQp19NCWkEKygb2OJ5zGKsS5DYZTLYodkH6x5IFG43QtVyeSv1C5oes4Whg31flg=="],
 
@@ -830,55 +830,15 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.27.1", "", {}, "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow=="],
-
-    "@es-joy/jsdoccomment/@typescript-eslint/types": ["@typescript-eslint/types@8.58.0", "", {}, "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww=="],
-
-    "@es-joy/jsdoccomment/jsdoc-type-pratt-parser": ["jsdoc-type-pratt-parser@7.2.0", "", {}, "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw=="],
-
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
-
-    "@eslint/compat/@eslint/core": ["@eslint/core@1.2.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ=="],
-
-    "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.54.0", "", { "dependencies": { "@typescript-eslint/types": "8.54.0", "@typescript-eslint/visitor-keys": "8.54.0" } }, "sha512-27rYVQku26j/PbHYcVfRPonmOlVI6gihHtXFbTdB5sb6qA0wdAQAbyXFVarQ5t4HRojIz64IV90YtsjQSSGlQg=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils": ["@typescript-eslint/utils@8.54.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.54.0", "@typescript-eslint/types": "8.54.0", "@typescript-eslint/typescript-estree": "8.54.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-9Cnda8GS57AQakvRyG0PTejJNlA2xhvyNtEVIMlDWOOeEyBkYWhGPnfrIAnqxLMTSTo6q8g12XVjjev5l1NvMA=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.54.0", "", { "dependencies": { "@typescript-eslint/types": "8.54.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA=="],
-
-    "@typescript-eslint/parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.58.2", "", { "dependencies": { "@typescript-eslint/types": "8.58.2", "@typescript-eslint/visitor-keys": "8.58.2" } }, "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q=="],
-
-    "@typescript-eslint/parser/@typescript-eslint/types": ["@typescript-eslint/types@8.58.2", "", {}, "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ=="],
-
-    "@typescript-eslint/parser/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.2", "", { "dependencies": { "@typescript-eslint/types": "8.58.2", "eslint-visitor-keys": "^5.0.0" } }, "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA=="],
-
-    "@typescript-eslint/project-service/@typescript-eslint/types": ["@typescript-eslint/types@8.58.2", "", {}, "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/types": ["@typescript-eslint/types@8.54.0", "", {}, "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.54.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.54.0", "@typescript-eslint/tsconfig-utils": "8.54.0", "@typescript-eslint/types": "8.54.0", "@typescript-eslint/visitor-keys": "8.54.0", "debug": "^4.4.3", "minimatch": "^9.0.5", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-BUwcskRaPvTk6fzVWgDPdUndLjB87KYDrN5EYGetnktoeAvPtO4ONHlAZDnj5VFnUANg0Sjm7j4usBlnoVMHwA=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/utils": ["@typescript-eslint/utils@8.54.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.54.0", "@typescript-eslint/types": "8.54.0", "@typescript-eslint/typescript-estree": "8.54.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-9Cnda8GS57AQakvRyG0PTejJNlA2xhvyNtEVIMlDWOOeEyBkYWhGPnfrIAnqxLMTSTo6q8g12XVjjev5l1NvMA=="],
-
-    "@typescript-eslint/typescript-estree/@typescript-eslint/types": ["@typescript-eslint/types@8.58.2", "", {}, "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ=="],
-
-    "@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.2", "", { "dependencies": { "@typescript-eslint/types": "8.58.2", "eslint-visitor-keys": "^5.0.0" } }, "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA=="],
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
-    "@typescript-eslint/typescript-estree/ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+    "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
-    "@typescript-eslint/utils/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.58.1", "", { "dependencies": { "@typescript-eslint/project-service": "8.58.1", "@typescript-eslint/tsconfig-utils": "8.58.1", "@typescript-eslint/types": "8.58.1", "@typescript-eslint/visitor-keys": "8.58.1", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg=="],
-
-    "ajv-formats/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
-
-    "ajv-keywords/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+    "ajv-keywords/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "clean-regexp/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
-
-    "cosmiconfig/js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -896,7 +856,7 @@
 
     "eslint-plugin-import/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
-    "eslint-plugin-import/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+    "eslint-plugin-import/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "eslint-plugin-jsdoc/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -906,75 +866,19 @@
 
     "eslint-plugin-n/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
-    "eslint-plugin-perfectionist/@typescript-eslint/utils": ["@typescript-eslint/utils@8.58.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.58.0", "@typescript-eslint/types": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA=="],
-
-    "eslint-plugin-regexp/comment-parser": ["comment-parser@1.4.5", "", {}, "sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw=="],
-
-    "eslint-plugin-unicorn/globals": ["globals@17.4.0", "", {}, "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw=="],
-
     "eslint-plugin-unicorn/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
-    "jest-worker/@types/node": ["@types/node@22.15.23", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-7Ec1zaFPF4RJ0eXu1YT/xgiebqwqoJz8rYPDi/O2BcZ++Wpt0Kq9cl0eg6NN6bYbPnR67ZLo7St5Q3UK0SnARw=="],
-
-    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+    "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "read-package-json-fast/json-parse-even-better-errors": ["json-parse-even-better-errors@4.0.0", "", {}, "sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA=="],
 
-    "schema-utils/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+    "schema-utils/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
-    "sort-package-json/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
-
-    "terser/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+    "sort-package-json/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
-    "terser-webpack-plugin/schema-utils": ["schema-utils@4.3.2", "", { "dependencies": { "@types/json-schema": "^7.0.9", "ajv": "^8.9.0", "ajv-formats": "^2.1.1", "ajv-keywords": "^5.1.0" } }, "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ=="],
-
-    "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
-
-    "ts-declaration-location/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
-
-    "typescript-eslint/@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.58.2", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.58.2", "@typescript-eslint/type-utils": "8.58.2", "@typescript-eslint/utils": "8.58.2", "@typescript-eslint/visitor-keys": "8.58.2", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.58.2", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw=="],
-
-    "typescript-eslint/@typescript-eslint/utils": ["@typescript-eslint/utils@8.58.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.58.2", "@typescript-eslint/types": "8.58.2", "@typescript-eslint/typescript-estree": "8.58.2" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA=="],
-
-    "webpack/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
-
-    "webpack/browserslist": ["browserslist@4.25.0", "", { "dependencies": { "caniuse-lite": "^1.0.30001718", "electron-to-chromium": "^1.5.160", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA=="],
-
     "webpack/eslint-scope": ["eslint-scope@5.1.1", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^4.1.1" } }, "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="],
-
-    "webpack/schema-utils": ["schema-utils@4.3.2", "", { "dependencies": { "@types/json-schema": "^7.0.9", "ajv": "^8.9.0", "ajv-formats": "^2.1.1", "ajv-keywords": "^5.1.0" } }, "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.54.0", "", {}, "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.54.0", "", {}, "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.54.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.54.0", "@typescript-eslint/tsconfig-utils": "8.54.0", "@typescript-eslint/types": "8.54.0", "@typescript-eslint/visitor-keys": "8.54.0", "debug": "^4.4.3", "minimatch": "^9.0.5", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-BUwcskRaPvTk6fzVWgDPdUndLjB87KYDrN5EYGetnktoeAvPtO4ONHlAZDnj5VFnUANg0Sjm7j4usBlnoVMHwA=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys/@typescript-eslint/types": ["@typescript-eslint/types@8.54.0", "", {}, "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.54.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.54.0", "@typescript-eslint/types": "^8.54.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-YPf+rvJ1s7MyiWM4uTRhE4DvBXrEV+d8oC3P9Y2eT7S+HBS0clybdMIPnhiATi9vZOYDc7OQ1L/i6ga6NFYK/g=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.54.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-dRgOyT2hPk/JwxNMZDsIXDgyl9axdJI3ogZ2XWhBPsnZUv+hPesa5iuhdYt2gzwA9t8RE5ytOJ6xB0moV0Ujvw=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.54.0", "", { "dependencies": { "@typescript-eslint/types": "8.54.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.54.0", "", { "dependencies": { "@typescript-eslint/types": "8.54.0", "@typescript-eslint/visitor-keys": "8.54.0" } }, "sha512-27rYVQku26j/PbHYcVfRPonmOlVI6gihHtXFbTdB5sb6qA0wdAQAbyXFVarQ5t4HRojIz64IV90YtsjQSSGlQg=="],
-
-    "@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.58.1", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.58.1", "@typescript-eslint/types": "^8.58.1", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g=="],
-
-    "@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.58.1", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw=="],
-
-    "@typescript-eslint/utils/@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
-    "@typescript-eslint/utils/@typescript-eslint/typescript-estree/ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -982,90 +886,12 @@
 
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
-    "eslint-plugin-import/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
-
-    "eslint-plugin-perfectionist/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0" } }, "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ=="],
-
-    "eslint-plugin-perfectionist/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.58.0", "", {}, "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww=="],
-
-    "eslint-plugin-perfectionist/@typescript-eslint/utils/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.58.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.58.0", "@typescript-eslint/tsconfig-utils": "8.58.0", "@typescript-eslint/types": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA=="],
-
-    "jest-worker/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "eslint-plugin-import/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "terser-webpack-plugin/schema-utils/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
-
-    "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.58.2", "", { "dependencies": { "@typescript-eslint/types": "8.58.2", "@typescript-eslint/visitor-keys": "8.58.2" } }, "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q=="],
-
-    "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.58.2", "", { "dependencies": { "@typescript-eslint/types": "8.58.2", "@typescript-eslint/typescript-estree": "8.58.2", "@typescript-eslint/utils": "8.58.2", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg=="],
-
-    "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.2", "", { "dependencies": { "@typescript-eslint/types": "8.58.2", "eslint-visitor-keys": "^5.0.0" } }, "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA=="],
-
-    "typescript-eslint/@typescript-eslint/eslint-plugin/ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
-
-    "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.58.2", "", { "dependencies": { "@typescript-eslint/types": "8.58.2", "@typescript-eslint/visitor-keys": "8.58.2" } }, "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q=="],
-
-    "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.58.2", "", {}, "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ=="],
-
-    "webpack/browserslist/caniuse-lite": ["caniuse-lite@1.0.30001724", "", {}, "sha512-WqJo7p0TbHDOythNTqYujmaJTvtYRZrjpP8TCvH6Vb9CYJerJNKamKzIWOM4BkQatWj9H2lYulpdAQNBe7QhNA=="],
-
-    "webpack/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.171", "", {}, "sha512-scWpzXEJEMrGJa4Y6m/tVotb0WuvNmasv3wWVzUAeCgKU0ToFOhUW6Z+xWnRQANMYGxN4ngJXIThgBJOqzVPCQ=="],
-
-    "webpack/browserslist/node-releases": ["node-releases@2.0.19", "", {}, "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="],
-
-    "webpack/browserslist/update-browserslist-db": ["update-browserslist-db@1.1.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw=="],
-
     "webpack/eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
 
-    "webpack/schema-utils/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.54.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.54.0", "@typescript-eslint/types": "^8.54.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-YPf+rvJ1s7MyiWM4uTRhE4DvBXrEV+d8oC3P9Y2eT7S+HBS0clybdMIPnhiATi9vZOYDc7OQ1L/i6ga6NFYK/g=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.54.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-dRgOyT2hPk/JwxNMZDsIXDgyl9axdJI3ogZ2XWhBPsnZUv+hPesa5iuhdYt2gzwA9t8RE5ytOJ6xB0moV0Ujvw=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.54.0", "", { "dependencies": { "@typescript-eslint/types": "8.54.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA=="],
-
     "eslint-plugin-import/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "eslint-plugin-perfectionist/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ=="],
-
-    "eslint-plugin-perfectionist/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.58.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.58.0", "@typescript-eslint/types": "^8.58.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg=="],
-
-    "eslint-plugin-perfectionist/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.58.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A=="],
-
-    "eslint-plugin-perfectionist/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ=="],
-
-    "eslint-plugin-perfectionist/@typescript-eslint/utils/@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
-    "eslint-plugin-perfectionist/@typescript-eslint/utils/@typescript-eslint/typescript-estree/ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
-
-    "terser-webpack-plugin/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.58.2", "", {}, "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ=="],
-
-    "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils/@typescript-eslint/types": ["@typescript-eslint/types@8.58.2", "", {}, "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ=="],
-
-    "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys/@typescript-eslint/types": ["@typescript-eslint/types@8.58.2", "", {}, "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ=="],
-
-    "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.2", "", { "dependencies": { "@typescript-eslint/types": "8.58.2", "eslint-visitor-keys": "^5.0.0" } }, "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA=="],
-
-    "webpack/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }
 }

--- a/toolkit/cli/pom.xml
+++ b/toolkit/cli/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>io.github.bbortt.snow-white.toolkit</groupId>
     <artifactId>toolkit</artifactId>
-    <version>1.0.0-SNAPSHOT-alpha.12</version>
+    <version>1.0.0-SNAPSHOT-alpha.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/toolkit/cli/pom.xml
+++ b/toolkit/cli/pom.xml
@@ -31,13 +31,13 @@
     <node.version>v22.20.0</node.version>
 
     <!-- SonarQube properties -->
-    <sonar.inclusions>src/**/*.ts,</sonar.inclusions>
-    <sonar.exclusions>
-      node_modules/**,
-      src/clients/**,
-    </sonar.exclusions>
+    <sonar.sources>src</sonar.sources>
+    <sonar.tests>src</sonar.tests>
 
-    <sonar.test.inclusions>src/**/*.spec.ts,</sonar.test.inclusions>
+    <sonar.inclusions>src/**/*.ts</sonar.inclusions>
+    <sonar.exclusions>node_modules/**,src/clients/**</sonar.exclusions>
+
+    <sonar.test.inclusions>src/**/*.spec.ts</sonar.test.inclusions>
 
     <sonar.javascript.lcov.reportPaths>target/coverage/lcov.info</sonar.javascript.lcov.reportPaths>
     <sonar.testExecutionReportPaths>target/test-results/bun/junit.xml</sonar.testExecutionReportPaths>

--- a/toolkit/cli/src/actions/calculate.spec.ts
+++ b/toolkit/cli/src/actions/calculate.spec.ts
@@ -9,7 +9,7 @@ import { exit } from 'node:process';
 
 import type { QualityGateApi } from '../clients/quality-gate-api';
 import type { ReportApi } from '../clients/report-api';
-import type { SanitizedOptions } from '../config/sanitized-options';
+import type { CalculateOptions } from '../config/sanitized-options';
 
 import { FetchError, ResponseError } from '../clients/quality-gate-api/runtime';
 import { QUALITY_GATE_CALCULATION_FAILED } from '../common/exit-codes';
@@ -40,7 +40,7 @@ describe('calculate action', () => {
     getReportByCalculationId: mock(),
   };
 
-  const defaultOptions: SanitizedOptions = {
+  const defaultOptions: CalculateOptions = {
     apiInformation: [{ apiName: 'test-api', apiVersion: '1.0.0', serviceName: 'test-service' }],
     async: true,
     qualityGate: 'test-gate',
@@ -110,7 +110,7 @@ describe('calculate action', () => {
 
       qualityGateApiMock.calculateQualityGateRaw.mockResolvedValue(mockApiResponse);
 
-      const optionsWithLookback: SanitizedOptions = {
+      const optionsWithLookback: CalculateOptions = {
         ...defaultOptions,
         lookbackWindow: '24h',
       };
@@ -138,7 +138,7 @@ describe('calculate action', () => {
 
       qualityGateApiMock.calculateQualityGateRaw.mockResolvedValue(mockApiResponse);
 
-      const optionsWithFilters: SanitizedOptions = {
+      const optionsWithFilters: CalculateOptions = {
         ...defaultOptions,
         attributeFilters: { environment: 'production', region: 'us-west-1' },
       };
@@ -168,7 +168,7 @@ describe('calculate action', () => {
 
       qualityGateApiMock.calculateQualityGateRaw.mockResolvedValue(mockApiResponse);
 
-      const fullOptions: SanitizedOptions = {
+      const fullOptions: CalculateOptions = {
         ...defaultOptions,
         attributeFilters: { environment: 'staging' },
         lookbackWindow: '7d',
@@ -204,7 +204,7 @@ describe('calculate action', () => {
   });
 
   describe('synchronous polling (async: false)', () => {
-    const syncOptions: SanitizedOptions = {
+    const syncOptions: CalculateOptions = {
       ...defaultOptions,
       async: false,
     };

--- a/toolkit/cli/src/actions/calculate.ts
+++ b/toolkit/cli/src/actions/calculate.ts
@@ -10,7 +10,7 @@ import { exit } from 'node:process';
 import type { CalculateQualityGateRequest, QualityGateApi } from '../clients/quality-gate-api';
 import type { ReportApi } from '../clients/report-api';
 import type { ListQualityGateReports200ResponseInner } from '../clients/report-api/models/ListQualityGateReports200ResponseInner';
-import type { SanitizedOptions } from '../config/sanitized-options';
+import type { CalculateOptions } from '../config/sanitized-options';
 
 import { FetchError, ResponseError } from '../clients/quality-gate-api/runtime';
 import { ListQualityGateReports200ResponseInnerStatusEnum } from '../clients/report-api/models/ListQualityGateReports200ResponseInner';
@@ -19,7 +19,7 @@ import { toDtos } from '../entity/mapper/api-information.mapper';
 
 const POLL_INTERVAL_MS = 2000;
 
-const calculateQualityGates = async (qualityGateApi: QualityGateApi, reportApi: ReportApi, options: SanitizedOptions): Promise<void> => {
+const calculateQualityGates = async (qualityGateApi: QualityGateApi, reportApi: ReportApi, options: CalculateOptions): Promise<void> => {
   console.log(chalk.blue(`🚀  Starting Quality-Gate calculation for ${options.apiInformation.length} API(s)...`));
   console.log(chalk.gray(`Base URL: ${options.url}`));
 
@@ -87,7 +87,7 @@ const pollCalculationResult = async (reportApi: ReportApi, calculationId: string
   }
 };
 
-export const calculate = async (qualityGateApi: QualityGateApi, reportApi: ReportApi, options: SanitizedOptions): Promise<void> => {
+export const calculate = async (qualityGateApi: QualityGateApi, reportApi: ReportApi, options: CalculateOptions): Promise<void> => {
   try {
     await calculateQualityGates(qualityGateApi, reportApi, options);
   } catch (error: unknown) {

--- a/toolkit/cli/src/actions/upload-prereleases.spec.ts
+++ b/toolkit/cli/src/actions/upload-prereleases.spec.ts
@@ -12,7 +12,8 @@ import type { ApiIndexApi } from '../clients/api-index-api';
 
 import { PRERELEASE_UPLOAD_FAILED } from '../common/exit-codes';
 import { scanGlob } from '../common/glob';
-import { DEFAULT_API_NAME_PATH, DEFAULT_API_VERSION_PATH, DEFAULT_SERVICE_NAME_PATH, uploadPrereleases } from './upload-prereleases';
+import { DEFAULT_API_NAME_PATH, DEFAULT_API_VERSION_PATH, DEFAULT_SERVICE_NAME_PATH } from '../common/openapi';
+import { uploadPrereleases } from './upload-prereleases';
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 mock.module('node:process', () => ({

--- a/toolkit/cli/src/actions/upload-prereleases.ts
+++ b/toolkit/cli/src/actions/upload-prereleases.ts
@@ -10,30 +10,20 @@ import { readFileSync } from 'node:fs';
 import { exit } from 'node:process';
 
 import type { ApiIndexApi, GetAllApis200ResponseInner, GetAllApis500Response } from '../clients/api-index-api';
+import type { UploadPrereleasesOptions } from '../config/sanitized-options.ts';
 
 import { GetAllApis200ResponseInnerApiTypeEnum } from '../clients/api-index-api';
 import { PRERELEASE_UPLOAD_FAILED } from '../common/exit-codes';
 import { scanGlob } from '../common/glob';
 
 // Default JSON paths mirror the api-sync-job's ArtifactoryProperties defaults.
-// The api-sync-job uses a parsed OpenAPI object model where extension fields are
-// normalised into an 'extensions' map (e.g. info.extensions.x-service-name).
-// The CLI reads raw YAML, so extensions sit directly on their parent object
-// (e.g. info.x-service-name).
+// The api-sync-job uses a parsed OpenAPI object model where extension fields are normalized into an 'extensions' map (e.g. info.extensions.x-service-name).
+// The CLI reads raw YAML, so extensions sit directly on their parent object (e.g. info.x-service-name).
 export const DEFAULT_API_NAME_PATH = 'info.title';
 export const DEFAULT_API_VERSION_PATH = 'info.version';
 export const DEFAULT_SERVICE_NAME_PATH = 'info.x-service-name';
 
-export interface UploadPrereleasesOptions {
-  globPattern: string;
-  url: string;
-  apiNamePath?: string;
-  apiVersionPath?: string;
-  serviceNamePath?: string;
-  ignoreExisting?: boolean;
-}
-
-const getNestedValue = (obj: unknown, path: string): string | undefined => {
+export const getNestedValue = (obj: unknown, path: string): string | undefined => {
   const parts = path.split('.');
   let current: unknown = obj;
   for (const part of parts) {

--- a/toolkit/cli/src/actions/upload-prereleases.ts
+++ b/toolkit/cli/src/actions/upload-prereleases.ts
@@ -15,31 +15,52 @@ import type { UploadPrereleasesOptions } from '../config/sanitized-options.ts';
 import { GetAllApis200ResponseInnerApiTypeEnum } from '../clients/api-index-api';
 import { PRERELEASE_UPLOAD_FAILED } from '../common/exit-codes';
 import { scanGlob } from '../common/glob';
-
-// Default JSON paths mirror the api-sync-job's ArtifactoryProperties defaults.
-// The api-sync-job uses a parsed OpenAPI object model where extension fields are normalized into an 'extensions' map (e.g. info.extensions.x-service-name).
-// The CLI reads raw YAML, so extensions sit directly on their parent object (e.g. info.x-service-name).
-export const DEFAULT_API_NAME_PATH = 'info.title';
-export const DEFAULT_API_VERSION_PATH = 'info.version';
-export const DEFAULT_SERVICE_NAME_PATH = 'info.x-service-name';
-
-export const getNestedValue = (obj: unknown, path: string): string | undefined => {
-  const parts = path.split('.');
-  let current: unknown = obj;
-  for (const part of parts) {
-    if (current && typeof current === 'object') {
-      current = (current as Record<string, unknown>)[part];
-    } else {
-      return undefined;
-    }
-  }
-  return typeof current === 'string' ? current : undefined;
-};
+import { DEFAULT_API_NAME_PATH, DEFAULT_API_VERSION_PATH, DEFAULT_SERVICE_NAME_PATH, extractApiSpecMetadata } from '../common/openapi';
 
 const isResponseError = (error: unknown): error is Error & { response: Response } =>
   error instanceof Error && error.name === 'ResponseError' && 'response' in error;
 
 const isFetchError = (error: unknown): boolean => error instanceof TypeError || (error instanceof Error && error.name === 'FetchError');
+
+const logResponseError = async (error: Error & { response: Response }): Promise<void> => {
+  console.debug(chalk.red(`\t  Status: ${error.response.status}`));
+  const body = (await error.response.json().catch(() => null)) as GetAllApis500Response | undefined;
+  if (body) {
+    console.error(chalk.red(`\t  Details: ${(body as { message: string }).message}`));
+  } else if (error.response.status === 409) {
+    console.error(chalk.red(`\t  Error: This API specification has already been indexed!`));
+  } else {
+    console.error(chalk.red(`\t  Error: ${error.response.statusText}`));
+  }
+};
+
+interface UploadErrorResult {
+  ignored: boolean;
+}
+
+const handleUploadError = async (
+  error: unknown,
+  file: string,
+  metadata: { apiName?: string; apiVersion?: string; serviceName?: string },
+  ignoreExisting: boolean,
+): Promise<UploadErrorResult> => {
+  console.error(chalk.red(`❌  ${file}: Upload failed.`));
+
+  if (isResponseError(error)) {
+    if (error.response.status === 409 && ignoreExisting) {
+      console.warn(chalk.yellow(`\t  ⚠️ Ignoring already existing ${metadata.serviceName}/${metadata.apiName}@${metadata.apiVersion}`));
+      return { ignored: true };
+    }
+    await logResponseError(error);
+  } else if (isFetchError(error)) {
+    console.error(chalk.red('\t  No response received from server.'));
+    console.error(chalk.gray('\t  Check if the service is running and accessible.'));
+  } else {
+    console.error(chalk.red(`\t  Error: ${error instanceof Error ? error.message : JSON.stringify(error)}`));
+  }
+
+  return { ignored: false };
+};
 
 export const uploadPrereleases = async (apiIndexApi: ApiIndexApi, options: UploadPrereleasesOptions): Promise<void> => {
   const { globPattern, ignoreExisting, url } = options;
@@ -67,32 +88,22 @@ export const uploadPrereleases = async (apiIndexApi: ApiIndexApi, options: Uploa
   let ignoredCount = 0;
 
   for (const file of files) {
-    let apiName: string | undefined;
-    let apiVersion: string | undefined;
-    let serviceName: string | undefined;
+    let uploadedMetadata: { apiName?: string; apiVersion?: string; serviceName?: string } = {};
 
     try {
       const content = readFileSync(file, 'utf8');
       const parsed = load(content);
+      const result = extractApiSpecMetadata(parsed, { apiNamePath, apiVersionPath, serviceNamePath });
 
-      apiName = getNestedValue(parsed, apiNamePath);
-      apiVersion = getNestedValue(parsed, apiVersionPath);
-      serviceName = getNestedValue(parsed, serviceNamePath);
-
-      if (!apiName || !apiVersion || !serviceName) {
+      if (!result.ok) {
         console.error(chalk.red(`❌  ${file}: Missing required metadata fields.`));
-        if (!apiName) {
-          console.error(chalk.red(`\t  '${apiNamePath}' not found or empty.`));
-        }
-        if (!apiVersion) {
-          console.error(chalk.red(`\t  '${apiVersionPath}' not found or empty.`));
-        }
-        if (!serviceName) {
-          console.error(chalk.red(`\t  '${serviceNamePath}' not found or empty.`));
-        }
+        result.missing.forEach(path => console.error(chalk.red(`\t  '${path}' not found or empty.`)));
         failCount++;
         continue;
       }
+
+      const { apiName, apiVersion, serviceName } = result.metadata;
+      uploadedMetadata = { apiName, apiVersion, serviceName };
 
       const getAllApis200ResponseInner: GetAllApis200ResponseInner = {
         apiName,
@@ -109,33 +120,12 @@ export const uploadPrereleases = async (apiIndexApi: ApiIndexApi, options: Uploa
       console.log(chalk.green(`✅  ${file}: Uploaded ${serviceName}/${apiName}@${apiVersion}`));
       successCount++;
     } catch (error: unknown) {
-      console.error(chalk.red(`❌  ${file}: Upload failed.`));
-
-      if (isResponseError(error)) {
-        if (error.response.status === 409 && ignoreExisting) {
-          console.warn(chalk.yellow(`\t  ⚠️ Ignoring already existing ${serviceName}/${apiName}@${apiVersion}`));
-          ignoredCount++;
-          // Subtract from failed count, because we later increase it anyway
-          failCount--;
-        } else {
-          console.debug(chalk.red(`\t  Status: ${error.response.status}`));
-          const body = (await error.response.json().catch(() => null)) as GetAllApis500Response | undefined;
-          if (body) {
-            console.error(chalk.red(`\t  Details: ${(body as { message: string }).message}`));
-          } else if (error.response.status === 409) {
-            console.error(chalk.red(`\t  Error: This API specification has already been indexed!`));
-          } else {
-            console.error(chalk.red(`\t  Error: ${error.response.statusText}`));
-          }
-        }
-      } else if (isFetchError(error)) {
-        console.error(chalk.red('\t  No response received from server.'));
-        console.error(chalk.gray('\t  Check if the service is running and accessible.'));
+      const { ignored } = await handleUploadError(error, file, uploadedMetadata, ignoreExisting ?? false);
+      if (ignored) {
+        ignoredCount++;
       } else {
-        console.error(chalk.red(`\t  Error: ${error instanceof Error ? error.message : JSON.stringify(error)}`));
+        failCount++;
       }
-
-      failCount++;
     }
   }
 

--- a/toolkit/cli/src/cli.spec.ts
+++ b/toolkit/cli/src/cli.spec.ts
@@ -431,7 +431,7 @@ info:
         const mockResponse: IWireMockResponse = { status: 201 };
         await wiremock.register({ endpoint: '/api/rest/v1/apis', method: 'POST' }, mockResponse);
 
-        const cliResult = await executeCLICommand(['upload-prereleases', '--prerelease-specs', tmpSpecFilename, '--url', WIREMOCK_URL]);
+        const cliResult = await executeCLICommand(['upload-prereleases', '--api-specs', tmpSpecFilename, '--url', WIREMOCK_URL]);
 
         expect(cliResult.exitCode, cliResult.stderr).toBe(0);
         expect(cliResult.stdout).toContain('🚀  Uploading prerelease API specifications matching:');
@@ -460,7 +460,7 @@ info:
         };
         await wiremock.register({ endpoint: '/api/rest/v1/apis', method: 'POST' }, mockResponse);
 
-        const cliResult = await executeCLICommand(['upload-prereleases', '--prerelease-specs', tmpSpecFilename, '--url', WIREMOCK_URL]);
+        const cliResult = await executeCLICommand(['upload-prereleases', '--api-specs', tmpSpecFilename, '--url', WIREMOCK_URL]);
 
         expect(cliResult.exitCode).not.toBe(0);
         expect(cliResult.stderr).toContain('❌');
@@ -486,7 +486,7 @@ info:
 
         const cliResult = await executeCLICommand([
           'upload-prereleases',
-          '--prerelease-specs',
+          '--api-specs',
           tmpSpecFilename,
           '--url',
           WIREMOCK_URL,
@@ -514,13 +514,7 @@ info:
         const mockResponse: IWireMockResponse = { status: 201 };
         await wiremock.register({ endpoint: '/api/rest/v1/apis', method: 'POST' }, mockResponse);
 
-        const cliResult = await executeCLICommand([
-          'upload-prereleases',
-          '--prerelease-specs',
-          tmpSpecFilename,
-          '--config-file',
-          tmpConfigPath,
-        ]);
+        const cliResult = await executeCLICommand(['upload-prereleases', '--api-specs', tmpSpecFilename, '--config-file', tmpConfigPath]);
 
         expect(cliResult.exitCode, cliResult.stderr).toBe(0);
         expect(cliResult.stdout).toContain(`Base URL: ${WIREMOCK_URL}`);

--- a/toolkit/cli/src/common/openapi.ts
+++ b/toolkit/cli/src/common/openapi.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Timon Borter <timon.borter@gmx.ch>
+ * Licensed under the Polyform Small Business License 1.0.0
+ * See LICENSE file for full details.
+ */
+
+// Default JSON paths mirror the api-sync-job's ArtifactoryProperties defaults.
+// The api-sync-job uses a parsed OpenAPI object model where extension fields are normalized into an 'extensions' map (e.g. info.extensions.x-service-name).
+// The CLI reads raw YAML, so extensions sit directly on their parent object (e.g. info.x-service-name).
+export const DEFAULT_API_NAME_PATH = 'info.title';
+export const DEFAULT_API_VERSION_PATH = 'info.version';
+export const DEFAULT_SERVICE_NAME_PATH = 'info.x-service-name';
+
+export const getNestedValue = (obj: unknown, path: string): string | undefined => {
+  const parts = path.split('.');
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current && typeof current === 'object') {
+      current = (current as Record<string, unknown>)[part];
+    } else {
+      return undefined;
+    }
+  }
+  return typeof current === 'string' ? current : undefined;
+};
+
+export interface ApiSpecPaths {
+  apiNamePath: string;
+  apiVersionPath: string;
+  serviceNamePath: string;
+}
+
+export interface ApiSpecMetadata {
+  apiName: string;
+  apiVersion: string;
+  serviceName: string;
+}
+
+export type ApiSpecResult = { ok: false; missing: string[] } | { ok: true; metadata: ApiSpecMetadata };
+
+/**
+ * Extracts API spec metadata from a parsed YAML/JSON document.
+ * Returns the metadata on success, or the list of missing field paths on failure.
+ */
+export const extractApiSpecMetadata = (parsed: unknown, paths: ApiSpecPaths): ApiSpecResult => {
+  const apiName = getNestedValue(parsed, paths.apiNamePath);
+  const apiVersion = getNestedValue(parsed, paths.apiVersionPath);
+  const serviceName = getNestedValue(parsed, paths.serviceNamePath);
+
+  if (apiName && apiVersion && serviceName) {
+    return { metadata: { apiName, apiVersion, serviceName }, ok: true };
+  }
+
+  const missing: string[] = [];
+  if (!apiName) {
+    missing.push(paths.apiNamePath);
+  }
+  if (!apiVersion) {
+    missing.push(paths.apiVersionPath);
+  }
+  if (!serviceName) {
+    missing.push(paths.serviceNamePath);
+  }
+  return { missing, ok: false };
+};

--- a/toolkit/cli/src/config/cli-options.ts
+++ b/toolkit/cli/src/config/cli-options.ts
@@ -9,7 +9,7 @@ export interface CliOptions {
 
   url?: string;
 
-  openApiSpecs?: string;
+  apiSpecs?: string;
 
   qualityGate?: string;
   serviceName?: string;
@@ -24,8 +24,6 @@ export interface CliOptions {
   apiNamePath?: string;
   apiVersionPath?: string;
   serviceNamePath?: string;
-
-  prereleaseSpecs: string;
 
   ignoreExisting?: boolean;
 }

--- a/toolkit/cli/src/config/cli-options.ts
+++ b/toolkit/cli/src/config/cli-options.ts
@@ -5,41 +5,27 @@
  */
 
 export interface CliOptions {
-  /**
-   * Configuration from file
-   */
   configFile?: string;
-  /**
-   * Resolving API specifications
-   */
+
+  url?: string;
+
   openApiSpecs?: string;
-  // Explicit configuration
+
   qualityGate?: string;
   serviceName?: string;
   apiName?: string;
   apiVersion?: string;
-  /**
-   * Base URL for Snow-White API.
-   */
-  url?: string;
-  /**
-   * JSON path configuration for upload-prereleases command.
-   */
+
+  lookbackWindow?: string;
+  filter?: string[];
+
+  async?: boolean;
+
   apiNamePath?: string;
   apiVersionPath?: string;
   serviceNamePath?: string;
-  /**
-   * The time window to consider for calculation (e.g., '1h', '24h', '7d').
-   */
-  lookbackWindow?: string;
-  /**
-   * Key-value pairs for filtering telemetry data (format: key=value).
-   * Can be specified multiple times.
-   */
-  filter?: string[];
-  /**
-   * Fire-and-forget mode: skip polling for the calculation result.
-   * When false (default), the CLI polls until the calculation completes.
-   */
-  async?: boolean;
+
+  prereleaseSpecs: string;
+
+  ignoreExisting?: boolean;
 }

--- a/toolkit/cli/src/config/sanitize-configuration.spec.ts
+++ b/toolkit/cli/src/config/sanitize-configuration.spec.ts
@@ -5,13 +5,15 @@
  */
 
 import { afterAll, beforeEach, describe, expect, it, jest, mock, spyOn } from 'bun:test';
+import { readFileSync } from 'node:fs';
 import { exit } from 'node:process';
 
 import type { CliOptions } from './cli-options';
-import type { SanitizedOptions } from './sanitized-options';
+import type { CalculateOptions } from './sanitized-options';
 
 import { DEFAULT_API_NAME_PATH, DEFAULT_API_VERSION_PATH, DEFAULT_SERVICE_NAME_PATH } from '../actions/upload-prereleases';
 import { INVALID_CONFIG_FORMAT } from '../common/exit-codes';
+import { scanGlob } from '../common/glob';
 import { resolveConfig } from './resolve-config';
 import { sanitizeCalculateOptions, sanitizeUploadPrereleasesOptions } from './sanitize-configuration';
 
@@ -25,6 +27,16 @@ mock.module('node:process', () => ({
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 mock.module('./resolve-config', () => ({
   resolveConfig: mock(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+mock.module('../common/glob', () => ({
+  scanGlob: mock(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+mock.module('node:fs', () => ({
+  readFileSync: mock(),
 }));
 
 const mockConsoleError = spyOn(console, 'error');
@@ -45,7 +57,7 @@ const incompleteApiInformation = [
   },
 ];
 
-const sanitizedOptions: SanitizedOptions = {
+const sanitizedOptions: CalculateOptions = {
   apiInformation: [
     {
       apiName: 'test-api',
@@ -65,14 +77,14 @@ describe('sanitizeConfiguration', () => {
 
     // @ts-expect-error TS2339: Property mockClear does not exist on type
     exit.mockClear();
+    // @ts-expect-error TS2339: Property mockReset does not exist on type
+    (resolveConfig as any).mockReset();
+    (scanGlob as any).mockReset();
+    (readFileSync as any).mockReset();
   });
 
   it.each([
-    // property configFile with any other property
-    {
-      configFile: 'config',
-      openApiSpecs: 'some-glob-pattern',
-    },
+    // configFile combined with any exact config parameter
     {
       configFile: 'config',
       serviceName: 'test-service',
@@ -85,20 +97,7 @@ describe('sanitizeConfiguration', () => {
       apiVersion: 'test-version',
       configFile: 'config',
     },
-    // property openApiSpecs with any other property
-    {
-      openApiSpecs: 'some-glob-pattern',
-      serviceName: 'test-service',
-    },
-    {
-      apiName: 'test-api',
-      openApiSpecs: 'some-glob-pattern',
-    },
-    {
-      apiVersion: 'test-version',
-      openApiSpecs: 'some-glob-pattern',
-    },
-  ])('should exit with code 3 when combination of parameters is invalid: %s', (options: Partial<CliOptions>) => {
+  ])('should exit with code 3 when configFile is combined with exact config params: %s', (options: Partial<CliOptions>) => {
     // @ts-expect-error TS2345: Argument of type Partial<CliOptions> is not assignable to parameter of type CliOptions
     expect(() => sanitizeCalculateOptions(options)).toThrowError('Process exited with code 3');
 
@@ -108,6 +107,34 @@ describe('sanitizeConfiguration', () => {
     );
     expect(mockConsoleError).toHaveBeenNthCalledWith(2, expect.stringContaining('\tGroup 1: serviceName, apiName, apiVersion'));
     expect(mockConsoleError).toHaveBeenNthCalledWith(3, expect.stringContaining('\tGroup 2: configFile'));
+
+    expect(exit).toHaveBeenCalledWith(INVALID_CONFIG_FORMAT);
+  });
+
+  it.each([
+    // openApiSpecs combined with any exact config parameter
+    {
+      openApiSpecs: 'some-glob-pattern',
+      serviceName: 'test-service',
+    },
+    {
+      apiName: 'test-api',
+      openApiSpecs: 'some-glob-pattern',
+    },
+    {
+      apiVersion: 'test-version',
+      openApiSpecs: 'some-glob-pattern',
+    },
+  ])('should exit with code 3 when openApiSpecs is combined with exact config params: %s', (options: Partial<CliOptions>) => {
+    // @ts-expect-error TS2345: Argument of type Partial<CliOptions> is not assignable to parameter of type CliOptions
+    expect(() => sanitizeCalculateOptions(options)).toThrowError('Process exited with code 3');
+
+    expect(mockConsoleError).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('❌  You cannot use options from multiple configuration groups together.'),
+    );
+    expect(mockConsoleError).toHaveBeenNthCalledWith(2, expect.stringContaining('\tGroup 1: serviceName, apiName, apiVersion'));
+    expect(mockConsoleError).toHaveBeenNthCalledWith(3, expect.stringContaining('\tGroup 2: openApiSpecs'));
 
     expect(exit).toHaveBeenCalledWith(INVALID_CONFIG_FORMAT);
   });
@@ -197,7 +224,7 @@ describe('sanitizeConfiguration', () => {
 
   describe('CLI parameter precedence over config file', () => {
     it('should override URL from config file with CLI parameter', () => {
-      const fileConfig: SanitizedOptions = {
+      const fileConfig: CalculateOptions = {
         ...sanitizedOptions,
         url: 'http://config-file-url.com',
       };
@@ -210,7 +237,7 @@ describe('sanitizeConfiguration', () => {
     });
 
     it('should override qualityGate from config file with CLI parameter', () => {
-      const fileConfig: SanitizedOptions = {
+      const fileConfig: CalculateOptions = {
         ...sanitizedOptions,
         qualityGate: 'file-gate',
       };
@@ -223,7 +250,7 @@ describe('sanitizeConfiguration', () => {
     });
 
     it('should override lookbackWindow from config file with CLI parameter', () => {
-      const fileConfig: SanitizedOptions = {
+      const fileConfig: CalculateOptions = {
         ...sanitizedOptions,
         lookbackWindow: '1h',
       };
@@ -238,7 +265,7 @@ describe('sanitizeConfiguration', () => {
     });
 
     it('should override attributeFilters from config file with CLI filters', () => {
-      const fileConfig: SanitizedOptions = {
+      const fileConfig: CalculateOptions = {
         ...sanitizedOptions,
         attributeFilters: { environment: 'production' },
       };
@@ -253,7 +280,7 @@ describe('sanitizeConfiguration', () => {
     });
 
     it('should not warn when CLI parameter matches config file value', () => {
-      const fileConfig: SanitizedOptions = {
+      const fileConfig: CalculateOptions = {
         ...sanitizedOptions,
         url: 'http://same-url.com',
       };
@@ -427,19 +454,132 @@ describe('sanitizeConfiguration', () => {
   });
 
   describe('OpenAPI glob pattern configuration', () => {
-    it('is not implemented yet', () => {
-      const options: CliOptions = {
-        openApiSpecs: 'some-glob-pattern',
-      };
+    const VALID_YAML = `
+openapi: 3.1.0
+info:
+  title: My Test API
+  version: 1.2.3
+  x-service-name: my-service
+`.trim();
 
-      expect(() => sanitizeCalculateOptions(options)).toThrowError('Process exited with code 0');
+    it('scans files and builds apiInformation when only --open-api-specs is provided', () => {
+      (scanGlob as any).mockReturnValue(['services/my-api/openapi.yaml']);
+      (readFileSync as any).mockReturnValue(VALID_YAML);
 
-      expect(mockConsoleError).not.toHaveBeenCalled();
+      const result = sanitizeCalculateOptions({
+        openApiSpecs: 'services/**/openapi.yaml',
+        qualityGate: 'basic-coverage',
+        url: 'http://localhost:9000',
+      } as CliOptions);
+
+      expect(result.apiInformation).toEqual([{ apiName: 'My Test API', apiVersion: '1.2.3', serviceName: 'my-service' }]);
+    });
+
+    it('uses custom JSON paths when provided', () => {
+      const customYaml = `
+metadata:
+  name: Custom API
+  release: 2.0.0
+  owner: custom-service
+`.trim();
+      (scanGlob as any).mockReturnValue(['custom.yaml']);
+      (readFileSync as any).mockReturnValue(customYaml);
+
+      const result = sanitizeCalculateOptions({
+        apiNamePath: 'metadata.name',
+        apiVersionPath: 'metadata.release',
+        openApiSpecs: '*.yaml',
+        qualityGate: 'basic-coverage',
+        serviceNamePath: 'metadata.owner',
+        url: 'http://localhost:9000',
+      } as CliOptions);
+
+      expect(result.apiInformation).toEqual([{ apiName: 'Custom API', apiVersion: '2.0.0', serviceName: 'custom-service' }]);
+    });
+
+    it('builds apiInformation from multiple matched files', () => {
+      const yaml2 = `
+openapi: 3.1.0
+info:
+  title: Second API
+  version: 2.0.0
+  x-service-name: second-service
+`.trim();
+      (scanGlob as any).mockReturnValue(['svc-a/openapi.yaml', 'svc-b/openapi.yaml']);
+      (readFileSync as any).mockReturnValueOnce(VALID_YAML).mockReturnValueOnce(yaml2);
+
+      const result = sanitizeCalculateOptions({
+        openApiSpecs: 'svc-*/openapi.yaml',
+        qualityGate: 'basic-coverage',
+        url: 'http://localhost:9000',
+      } as CliOptions);
+
+      expect(result.apiInformation).toHaveLength(2);
+      expect(result.apiInformation).toContainEqual({ apiName: 'My Test API', apiVersion: '1.2.3', serviceName: 'my-service' });
+      expect(result.apiInformation).toContainEqual({ apiName: 'Second API', apiVersion: '2.0.0', serviceName: 'second-service' });
+    });
+
+    it('warns and returns empty array when no files match the pattern', () => {
+      (scanGlob as any).mockReturnValue([]);
+
+      expect(() =>
+        sanitizeCalculateOptions({
+          openApiSpecs: 'services/**/openapi.yaml',
+          qualityGate: 'basic-coverage',
+          url: 'http://localhost:9000',
+        } as CliOptions),
+      ).toThrowError('Process exited with code 3');
+
+      expect(mockConsoleWarn).toHaveBeenCalledWith(expect.stringContaining('⚠️  No files matched the pattern: services/**/openapi.yaml'));
+    });
+
+    it('exits with code 3 when a file is missing required metadata fields', () => {
+      (scanGlob as any).mockReturnValue(['openapi.yaml']);
+      (readFileSync as any).mockReturnValue('openapi: 3.1.0');
+
+      expect(() =>
+        sanitizeCalculateOptions({
+          openApiSpecs: '*.yaml',
+          qualityGate: 'basic-coverage',
+          url: 'http://localhost:9000',
+        } as CliOptions),
+      ).toThrowError('Process exited with code 3');
+
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('❌  openapi.yaml: Missing required metadata fields.'));
+      expect(exit).toHaveBeenCalledWith(INVALID_CONFIG_FORMAT);
+    });
+
+    it('ignores --open-api-specs and warns when config file already has apiInformation', () => {
+      (resolveConfig as any).mockReturnValueOnce({
+        apiInformation: [{ apiName: 'existing-api', apiVersion: '1.0.0', serviceName: 'existing-service' }],
+        qualityGate: 'basic-coverage',
+        url: 'http://localhost:9000',
+      });
+
+      const result = sanitizeCalculateOptions({
+        configFile: 'snow-white.json',
+        openApiSpecs: 'services/**/openapi.yaml',
+      } as CliOptions);
+
+      expect(scanGlob).not.toHaveBeenCalled();
+      expect(result.apiInformation).toEqual([{ apiName: 'existing-api', apiVersion: '1.0.0', serviceName: 'existing-service' }]);
       expect(mockConsoleWarn).toHaveBeenCalledWith(
-        expect.stringContaining('⚠️  OpenAPI specs are not yet implemented. Using provided options as is.'),
+        expect.stringContaining('⚠️  --open-api-specs is ignored because apiInformation is already defined in the configuration.'),
       );
+    });
 
-      expect(exit).toHaveBeenCalledWith(0);
+    it('uses glob when config file is present but has no apiInformation', () => {
+      (resolveConfig as any).mockReturnValueOnce({ qualityGate: 'basic-coverage', url: 'http://localhost:9000' });
+      (scanGlob as any).mockReturnValue(['services/my-api/openapi.yaml']);
+      (readFileSync as any).mockReturnValue(VALID_YAML);
+
+      const result = sanitizeCalculateOptions({
+        configFile: 'snow-white.json',
+        openApiSpecs: 'services/**/openapi.yaml',
+      } as CliOptions);
+
+      expect(result.apiInformation).toEqual([{ apiName: 'My Test API', apiVersion: '1.2.3', serviceName: 'my-service' }]);
+      expect(mockConsoleWarn).not.toHaveBeenCalledWith(expect.stringContaining('--open-api-specs is ignored'));
     });
   });
 

--- a/toolkit/cli/src/config/sanitize-configuration.spec.ts
+++ b/toolkit/cli/src/config/sanitize-configuration.spec.ts
@@ -112,20 +112,20 @@ describe('sanitizeConfiguration', () => {
   });
 
   it.each([
-    // openApiSpecs combined with any exact config parameter
+    // apiSpecs combined with any exact config parameter
     {
-      openApiSpecs: 'some-glob-pattern',
+      apiSpecs: 'some-glob-pattern',
       serviceName: 'test-service',
     },
     {
       apiName: 'test-api',
-      openApiSpecs: 'some-glob-pattern',
+      apiSpecs: 'some-glob-pattern',
     },
     {
+      apiSpecs: 'some-glob-pattern',
       apiVersion: 'test-version',
-      openApiSpecs: 'some-glob-pattern',
     },
-  ])('should exit with code 3 when openApiSpecs is combined with exact config params: %s', (options: Partial<CliOptions>) => {
+  ])('should exit with code 3 when apiSpecs is combined with exact config params: %s', (options: Partial<CliOptions>) => {
     // @ts-expect-error TS2345: Argument of type Partial<CliOptions> is not assignable to parameter of type CliOptions
     expect(() => sanitizeCalculateOptions(options)).toThrowError('Process exited with code 3');
 
@@ -134,7 +134,7 @@ describe('sanitizeConfiguration', () => {
       expect.stringContaining('❌  You cannot use options from multiple configuration groups together.'),
     );
     expect(mockConsoleError).toHaveBeenNthCalledWith(2, expect.stringContaining('\tGroup 1: serviceName, apiName, apiVersion'));
-    expect(mockConsoleError).toHaveBeenNthCalledWith(3, expect.stringContaining('\tGroup 2: openApiSpecs'));
+    expect(mockConsoleError).toHaveBeenNthCalledWith(3, expect.stringContaining('\tGroup 2: apiSpecs'));
 
     expect(exit).toHaveBeenCalledWith(INVALID_CONFIG_FORMAT);
   });
@@ -467,7 +467,7 @@ info:
       (readFileSync as any).mockReturnValue(VALID_YAML);
 
       const result = sanitizeCalculateOptions({
-        openApiSpecs: 'services/**/openapi.yaml',
+        apiSpecs: 'services/**/openapi.yaml',
         qualityGate: 'basic-coverage',
         url: 'http://localhost:9000',
       } as CliOptions);
@@ -487,8 +487,8 @@ metadata:
 
       const result = sanitizeCalculateOptions({
         apiNamePath: 'metadata.name',
+        apiSpecs: '*.yaml',
         apiVersionPath: 'metadata.release',
-        openApiSpecs: '*.yaml',
         qualityGate: 'basic-coverage',
         serviceNamePath: 'metadata.owner',
         url: 'http://localhost:9000',
@@ -509,7 +509,7 @@ info:
       (readFileSync as any).mockReturnValueOnce(VALID_YAML).mockReturnValueOnce(yaml2);
 
       const result = sanitizeCalculateOptions({
-        openApiSpecs: 'svc-*/openapi.yaml',
+        apiSpecs: 'svc-*/openapi.yaml',
         qualityGate: 'basic-coverage',
         url: 'http://localhost:9000',
       } as CliOptions);
@@ -524,7 +524,7 @@ info:
 
       expect(() =>
         sanitizeCalculateOptions({
-          openApiSpecs: 'services/**/openapi.yaml',
+          apiSpecs: 'services/**/openapi.yaml',
           qualityGate: 'basic-coverage',
           url: 'http://localhost:9000',
         } as CliOptions),
@@ -539,7 +539,7 @@ info:
 
       expect(() =>
         sanitizeCalculateOptions({
-          openApiSpecs: '*.yaml',
+          apiSpecs: '*.yaml',
           qualityGate: 'basic-coverage',
           url: 'http://localhost:9000',
         } as CliOptions),
@@ -549,7 +549,7 @@ info:
       expect(exit).toHaveBeenCalledWith(INVALID_CONFIG_FORMAT);
     });
 
-    it('ignores --open-api-specs and warns when config file already has apiInformation', () => {
+    it('ignores --api-specs and warns when config file already has apiInformation', () => {
       (resolveConfig as any).mockReturnValueOnce({
         apiInformation: [{ apiName: 'existing-api', apiVersion: '1.0.0', serviceName: 'existing-service' }],
         qualityGate: 'basic-coverage',
@@ -557,14 +557,14 @@ info:
       });
 
       const result = sanitizeCalculateOptions({
+        apiSpecs: 'services/**/openapi.yaml',
         configFile: 'snow-white.json',
-        openApiSpecs: 'services/**/openapi.yaml',
       } as CliOptions);
 
       expect(scanGlob).not.toHaveBeenCalled();
       expect(result.apiInformation).toEqual([{ apiName: 'existing-api', apiVersion: '1.0.0', serviceName: 'existing-service' }]);
       expect(mockConsoleWarn).toHaveBeenCalledWith(
-        expect.stringContaining('⚠️  --open-api-specs is ignored because apiInformation is already defined in the configuration.'),
+        expect.stringContaining('⚠️  --api-specs is ignored because apiInformation is already defined in the configuration.'),
       );
     });
 
@@ -574,12 +574,47 @@ info:
       (readFileSync as any).mockReturnValue(VALID_YAML);
 
       const result = sanitizeCalculateOptions({
+        apiSpecs: 'services/**/openapi.yaml',
         configFile: 'snow-white.json',
-        openApiSpecs: 'services/**/openapi.yaml',
       } as CliOptions);
 
       expect(result.apiInformation).toEqual([{ apiName: 'My Test API', apiVersion: '1.2.3', serviceName: 'my-service' }]);
-      expect(mockConsoleWarn).not.toHaveBeenCalledWith(expect.stringContaining('--open-api-specs is ignored'));
+      expect(mockConsoleWarn).not.toHaveBeenCalledWith(expect.stringContaining('--api-specs is ignored'));
+    });
+
+    it('reads apiSpecs from config file when not provided via CLI', () => {
+      (resolveConfig as any).mockReturnValueOnce({
+        apiSpecs: 'services/**/openapi.yaml',
+        qualityGate: 'basic-coverage',
+        url: 'http://localhost:9000',
+      });
+      (scanGlob as any).mockReturnValue(['services/my-api/openapi.yaml']);
+      (readFileSync as any).mockReturnValue(VALID_YAML);
+
+      const result = sanitizeCalculateOptions({ configFile: 'snow-white.json' } as CliOptions);
+
+      expect(result.apiInformation).toEqual([{ apiName: 'My Test API', apiVersion: '1.2.3', serviceName: 'my-service' }]);
+    });
+
+    it('warns when CLI --api-specs overrides config file apiSpecs', () => {
+      (resolveConfig as any).mockReturnValueOnce({
+        apiSpecs: 'old/**/openapi.yaml',
+        qualityGate: 'basic-coverage',
+        url: 'http://localhost:9000',
+      });
+      (scanGlob as any).mockReturnValue(['services/my-api/openapi.yaml']);
+      (readFileSync as any).mockReturnValue(VALID_YAML);
+
+      sanitizeCalculateOptions({
+        apiSpecs: 'services/**/openapi.yaml',
+        configFile: 'snow-white.json',
+      } as CliOptions);
+
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '⚠️  CLI parameter --api-specs overrides config file value: "old/**/openapi.yaml" → "services/**/openapi.yaml"',
+        ),
+      );
     });
   });
 
@@ -623,7 +658,7 @@ describe('sanitizeUploadPrereleasesOptions', () => {
 
   describe('URL resolution', () => {
     it('should use CLI url directly without consulting the config file', () => {
-      const result = sanitizeUploadPrereleasesOptions({ prereleaseSpecs: '*.yaml', url: BASE_URL });
+      const result = sanitizeUploadPrereleasesOptions({ apiSpecs: '*.yaml', url: BASE_URL });
 
       expect(resolveConfig).not.toHaveBeenCalled();
       expect(result.url).toBe(BASE_URL);
@@ -632,7 +667,7 @@ describe('sanitizeUploadPrereleasesOptions', () => {
     it('should read URL from config file when --url is not provided', () => {
       (resolveConfig as any).mockReturnValueOnce({ url: BASE_URL });
 
-      const result = sanitizeUploadPrereleasesOptions({ prereleaseSpecs: '*.yaml' });
+      const result = sanitizeUploadPrereleasesOptions({ apiSpecs: '*.yaml' });
 
       expect(resolveConfig).toHaveBeenCalledWith(undefined);
       expect(result.url).toBe(BASE_URL);
@@ -641,7 +676,7 @@ describe('sanitizeUploadPrereleasesOptions', () => {
     it('should pass --config-file path to resolveConfig', () => {
       (resolveConfig as any).mockReturnValueOnce({ url: BASE_URL });
 
-      sanitizeUploadPrereleasesOptions({ configFile: '/path/to/config.json', prereleaseSpecs: '*.yaml' });
+      sanitizeUploadPrereleasesOptions({ apiSpecs: '*.yaml', configFile: '/path/to/config.json' });
 
       expect(resolveConfig).toHaveBeenCalledWith('/path/to/config.json');
     });
@@ -649,7 +684,7 @@ describe('sanitizeUploadPrereleasesOptions', () => {
     it('should exit with code 3 when URL is absent from both CLI and config file', () => {
       (resolveConfig as any).mockReturnValueOnce({});
 
-      expect(() => sanitizeUploadPrereleasesOptions({ prereleaseSpecs: '*.yaml' })).toThrowError('Process exited with code 3');
+      expect(() => sanitizeUploadPrereleasesOptions({ apiSpecs: '*.yaml' })).toThrowError('Process exited with code 3');
 
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining('❌  Snow-White base URL must be defined via --url or in the configuration file.'),
@@ -661,8 +696,8 @@ describe('sanitizeUploadPrereleasesOptions', () => {
       (resolveConfig as any).mockReturnValueOnce({ url: 'http://config-url.com' });
 
       const result = sanitizeUploadPrereleasesOptions({
+        apiSpecs: '*.yaml',
         configFile: 'config.json',
-        prereleaseSpecs: '*.yaml',
         url: 'http://cli-url.com',
       });
 
@@ -675,7 +710,7 @@ describe('sanitizeUploadPrereleasesOptions', () => {
     it('should not warn when CLI url matches config file url', () => {
       (resolveConfig as any).mockReturnValueOnce({ url: BASE_URL });
 
-      const result = sanitizeUploadPrereleasesOptions({ configFile: 'config.json', prereleaseSpecs: '*.yaml', url: BASE_URL });
+      const result = sanitizeUploadPrereleasesOptions({ apiSpecs: '*.yaml', configFile: 'config.json', url: BASE_URL });
 
       expect(result.url).toBe(BASE_URL);
       expect(mockConsoleWarn).not.toHaveBeenCalled();
@@ -686,7 +721,7 @@ describe('sanitizeUploadPrereleasesOptions', () => {
     it('should use hardcoded defaults when no CLI or config file values are provided', () => {
       (resolveConfig as any).mockReturnValueOnce({ url: BASE_URL });
 
-      const result = sanitizeUploadPrereleasesOptions({ prereleaseSpecs: '*.yaml' });
+      const result = sanitizeUploadPrereleasesOptions({ apiSpecs: '*.yaml' });
 
       expect(result.apiNamePath).toBe(DEFAULT_API_NAME_PATH);
       expect(result.apiVersionPath).toBe(DEFAULT_API_VERSION_PATH);
@@ -701,7 +736,7 @@ describe('sanitizeUploadPrereleasesOptions', () => {
         url: BASE_URL,
       });
 
-      const result = sanitizeUploadPrereleasesOptions({ prereleaseSpecs: '*.yaml' });
+      const result = sanitizeUploadPrereleasesOptions({ apiSpecs: '*.yaml' });
 
       expect(result.apiNamePath).toBe('custom.name');
       expect(result.apiVersionPath).toBe('custom.version');
@@ -718,9 +753,9 @@ describe('sanitizeUploadPrereleasesOptions', () => {
 
       const result = sanitizeUploadPrereleasesOptions({
         apiNamePath: 'cli.name',
+        apiSpecs: '*.yaml',
         apiVersionPath: 'cli.version',
         configFile: 'config.json',
-        prereleaseSpecs: '*.yaml',
         serviceNamePath: 'cli.service',
       });
 
@@ -732,7 +767,7 @@ describe('sanitizeUploadPrereleasesOptions', () => {
     it('should warn when CLI api-name-path overrides config file value', () => {
       (resolveConfig as any).mockReturnValueOnce({ apiNamePath: 'config.name', url: BASE_URL });
 
-      sanitizeUploadPrereleasesOptions({ apiNamePath: 'cli.name', configFile: 'config.json', prereleaseSpecs: '*.yaml' });
+      sanitizeUploadPrereleasesOptions({ apiNamePath: 'cli.name', apiSpecs: '*.yaml', configFile: 'config.json' });
 
       expect(mockConsoleWarn).toHaveBeenCalledWith(
         expect.stringContaining('⚠️  CLI parameter --api-name-path overrides config file value: "config.name" → "cli.name"'),
@@ -742,7 +777,7 @@ describe('sanitizeUploadPrereleasesOptions', () => {
     it('should warn when CLI api-version-path overrides config file value', () => {
       (resolveConfig as any).mockReturnValueOnce({ apiVersionPath: 'config.version', url: BASE_URL });
 
-      sanitizeUploadPrereleasesOptions({ apiVersionPath: 'cli.version', configFile: 'config.json', prereleaseSpecs: '*.yaml' });
+      sanitizeUploadPrereleasesOptions({ apiSpecs: '*.yaml', apiVersionPath: 'cli.version', configFile: 'config.json' });
 
       expect(mockConsoleWarn).toHaveBeenCalledWith(
         expect.stringContaining('⚠️  CLI parameter --api-version-path overrides config file value: "config.version" → "cli.version"'),
@@ -752,7 +787,7 @@ describe('sanitizeUploadPrereleasesOptions', () => {
     it('should warn when CLI service-name-path overrides config file value', () => {
       (resolveConfig as any).mockReturnValueOnce({ serviceNamePath: 'config.service', url: BASE_URL });
 
-      sanitizeUploadPrereleasesOptions({ configFile: 'config.json', prereleaseSpecs: '*.yaml', serviceNamePath: 'cli.service' });
+      sanitizeUploadPrereleasesOptions({ apiSpecs: '*.yaml', configFile: 'config.json', serviceNamePath: 'cli.service' });
 
       expect(mockConsoleWarn).toHaveBeenCalledWith(
         expect.stringContaining('⚠️  CLI parameter --service-name-path overrides config file value: "config.service" → "cli.service"'),
@@ -760,11 +795,50 @@ describe('sanitizeUploadPrereleasesOptions', () => {
     });
   });
 
+  describe('apiSpecs resolution', () => {
+    it('should use CLI --api-specs directly when provided', () => {
+      const result = sanitizeUploadPrereleasesOptions({ apiSpecs: 'services/**/openapi.yaml', url: BASE_URL });
+
+      expect(result.globPattern).toBe('services/**/openapi.yaml');
+      expect(resolveConfig).not.toHaveBeenCalled();
+    });
+
+    it('should read apiSpecs from config file when not provided via CLI', () => {
+      (resolveConfig as any).mockReturnValueOnce({ apiSpecs: 'services/**/openapi.yaml', url: BASE_URL });
+
+      const result = sanitizeUploadPrereleasesOptions({});
+
+      expect(result.globPattern).toBe('services/**/openapi.yaml');
+    });
+
+    it('should warn when CLI --api-specs overrides config file value', () => {
+      (resolveConfig as any).mockReturnValueOnce({ apiSpecs: 'old/**/openapi.yaml', url: BASE_URL });
+
+      const result = sanitizeUploadPrereleasesOptions({ apiSpecs: 'new/**/openapi.yaml', configFile: 'config.json' });
+
+      expect(result.globPattern).toBe('new/**/openapi.yaml');
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
+        expect.stringContaining('⚠️  CLI parameter --api-specs overrides config file value: "old/**/openapi.yaml" → "new/**/openapi.yaml"'),
+      );
+    });
+
+    it('should exit with code 3 when apiSpecs is absent from both CLI and config file', () => {
+      (resolveConfig as any).mockReturnValueOnce({ url: BASE_URL });
+
+      expect(() => sanitizeUploadPrereleasesOptions({})).toThrowError('Process exited with code 3');
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('❌  API specs glob pattern must be defined via --api-specs or in the configuration file.'),
+      );
+      expect(exit).toHaveBeenCalledWith(INVALID_CONFIG_FORMAT);
+    });
+  });
+
   describe('option passthrough', () => {
     it('should pass through globPattern and ignoreExisting', () => {
       const result = sanitizeUploadPrereleasesOptions({
+        apiSpecs: 'services/**/openapi.yaml',
         ignoreExisting: true,
-        prereleaseSpecs: 'services/**/openapi.yaml',
         url: BASE_URL,
       });
 
@@ -773,7 +847,7 @@ describe('sanitizeUploadPrereleasesOptions', () => {
     });
 
     it('should default ignoreExisting to false when not provided', () => {
-      const result = sanitizeUploadPrereleasesOptions({ prereleaseSpecs: '*.yaml', url: BASE_URL });
+      const result = sanitizeUploadPrereleasesOptions({ apiSpecs: '*.yaml', url: BASE_URL });
 
       expect(result.ignoreExisting).toBe(false);
     });

--- a/toolkit/cli/src/config/sanitize-configuration.spec.ts
+++ b/toolkit/cli/src/config/sanitize-configuration.spec.ts
@@ -11,9 +11,9 @@ import { exit } from 'node:process';
 import type { CliOptions } from './cli-options';
 import type { CalculateOptions } from './sanitized-options';
 
-import { DEFAULT_API_NAME_PATH, DEFAULT_API_VERSION_PATH, DEFAULT_SERVICE_NAME_PATH } from '../actions/upload-prereleases';
 import { INVALID_CONFIG_FORMAT } from '../common/exit-codes';
 import { scanGlob } from '../common/glob';
+import { DEFAULT_API_NAME_PATH, DEFAULT_API_VERSION_PATH, DEFAULT_SERVICE_NAME_PATH } from '../common/openapi';
 import { resolveConfig } from './resolve-config';
 import { sanitizeCalculateOptions, sanitizeUploadPrereleasesOptions } from './sanitize-configuration';
 

--- a/toolkit/cli/src/config/sanitize-configuration.ts
+++ b/toolkit/cli/src/config/sanitize-configuration.ts
@@ -12,9 +12,9 @@ import { exit } from 'node:process';
 import type { CliOptions } from './cli-options';
 import type { ApiInformation, CalculateOptions, UploadPrereleasesOptions } from './sanitized-options';
 
-import { DEFAULT_API_NAME_PATH, DEFAULT_API_VERSION_PATH, DEFAULT_SERVICE_NAME_PATH, getNestedValue } from '../actions/upload-prereleases';
 import { INVALID_CONFIG_FORMAT } from '../common/exit-codes';
 import { scanGlob } from '../common/glob';
+import { DEFAULT_API_NAME_PATH, DEFAULT_API_VERSION_PATH, DEFAULT_SERVICE_NAME_PATH, extractApiSpecMetadata } from '../common/openapi';
 import { resolveConfig } from './resolve-config';
 
 const exactConfigurationGroup = Object.freeze(['serviceName', 'apiName', 'apiVersion']);
@@ -159,26 +159,16 @@ const loadApiInformationFromGlob = (globPattern: string, options: CliOptions, fi
     try {
       const content = readFileSync(file, 'utf8');
       const parsed = load(content);
+      const result = extractApiSpecMetadata(parsed, { apiNamePath, apiVersionPath, serviceNamePath });
 
-      const apiName = getNestedValue(parsed, apiNamePath);
-      const apiVersion = getNestedValue(parsed, apiVersionPath);
-      const serviceName = getNestedValue(parsed, serviceNamePath);
-
-      if (!apiName || !apiVersion || !serviceName) {
+      if (!result.ok) {
         console.error(chalk.red(`❌  ${file}: Missing required metadata fields.`));
-        if (!apiName) {
-          console.error(chalk.red(`\t  '${apiNamePath}' not found or empty.`));
-        }
-        if (!apiVersion) {
-          console.error(chalk.red(`\t  '${apiVersionPath}' not found or empty.`));
-        }
-        if (!serviceName) {
-          console.error(chalk.red(`\t  '${serviceNamePath}' not found or empty.`));
-        }
+        result.missing.forEach(path => console.error(chalk.red(`\t  '${path}' not found or empty.`)));
         hasErrors = true;
         continue;
       }
 
+      const { apiName, apiVersion, serviceName } = result.metadata;
       apiInformation.push({ apiName, apiVersion, serviceName });
       console.log(chalk.gray(`  ✓ ${file}: ${serviceName}/${apiName}@${apiVersion}`));
     } catch (error) {

--- a/toolkit/cli/src/config/sanitize-configuration.ts
+++ b/toolkit/cli/src/config/sanitize-configuration.ts
@@ -5,18 +5,20 @@
  */
 
 import chalk from 'chalk';
+import { load } from 'js-yaml';
+import { readFileSync } from 'node:fs';
 import { exit } from 'node:process';
 
-import type { UploadPrereleasesOptions } from '../actions/upload-prereleases';
 import type { CliOptions } from './cli-options';
-import type { SanitizedOptions } from './sanitized-options';
+import type { ApiInformation, CalculateOptions, UploadPrereleasesOptions } from './sanitized-options';
 
-import { DEFAULT_API_NAME_PATH, DEFAULT_API_VERSION_PATH, DEFAULT_SERVICE_NAME_PATH } from '../actions/upload-prereleases';
+import { DEFAULT_API_NAME_PATH, DEFAULT_API_VERSION_PATH, DEFAULT_SERVICE_NAME_PATH, getNestedValue } from '../actions/upload-prereleases';
 import { INVALID_CONFIG_FORMAT } from '../common/exit-codes';
+import { scanGlob } from '../common/glob';
 import { resolveConfig } from './resolve-config';
 
 const exactConfigurationGroup = Object.freeze(['serviceName', 'apiName', 'apiVersion']);
-const distinctConfigGroups = Object.freeze([exactConfigurationGroup, ['configFile'], ['openApiSpecs']]);
+const distinctConfigGroups = Object.freeze([exactConfigurationGroup, ['configFile']]);
 
 const exitWithCodeInvalidConfig = (): void => {
   exit(INVALID_CONFIG_FORMAT);
@@ -56,7 +58,7 @@ const parseFilters = (filters?: string[]): Record<string, string> | undefined =>
  * Merges CLI options over file config, with CLI taking precedence.
  * Logs warnings when CLI options override file config values.
  */
-const mergeWithCliOverrides = (fileConfig: Partial<SanitizedOptions>, cliOptions: CliOptions): Partial<SanitizedOptions> => {
+const mergeWithCliOverrides = (fileConfig: Partial<CalculateOptions>, cliOptions: CliOptions): Partial<CalculateOptions> => {
   const result = { ...fileConfig };
 
   // URL override
@@ -136,7 +138,74 @@ const validateConfigurationFromFile = (options: CliOptions): CliOptions => {
   return options;
 };
 
+const loadApiInformationFromGlob = (options: CliOptions): ApiInformation[] => {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const globPattern = options.openApiSpecs!;
+  const apiNamePath = options.apiNamePath ?? DEFAULT_API_NAME_PATH;
+  const apiVersionPath = options.apiVersionPath ?? DEFAULT_API_VERSION_PATH;
+  const serviceNamePath = options.serviceNamePath ?? DEFAULT_SERVICE_NAME_PATH;
+
+  const files = scanGlob(globPattern, process.cwd());
+
+  if (files.length === 0) {
+    console.warn(chalk.yellow(`⚠️  No files matched the pattern: ${globPattern}`));
+    return [];
+  }
+
+  console.log(chalk.gray(`Found ${files.length} file(s) matching pattern: ${globPattern}`));
+
+  const apiInformation: ApiInformation[] = [];
+  let hasErrors = false;
+
+  for (const file of files) {
+    try {
+      const content = readFileSync(file, 'utf8');
+      const parsed = load(content);
+
+      const apiName = getNestedValue(parsed, apiNamePath);
+      const apiVersion = getNestedValue(parsed, apiVersionPath);
+      const serviceName = getNestedValue(parsed, serviceNamePath);
+
+      if (!apiName || !apiVersion || !serviceName) {
+        console.error(chalk.red(`❌  ${file}: Missing required metadata fields.`));
+        if (!apiName) {
+          console.error(chalk.red(`\t  '${apiNamePath}' not found or empty.`));
+        }
+        if (!apiVersion) {
+          console.error(chalk.red(`\t  '${apiVersionPath}' not found or empty.`));
+        }
+        if (!serviceName) {
+          console.error(chalk.red(`\t  '${serviceNamePath}' not found or empty.`));
+        }
+        hasErrors = true;
+        continue;
+      }
+
+      apiInformation.push({ apiName, apiVersion, serviceName });
+      console.log(chalk.gray(`  ✓ ${file}: ${serviceName}/${apiName}@${apiVersion}`));
+    } catch (error) {
+      console.error(chalk.red(`❌  ${file}: Failed to parse file.`));
+      console.error(chalk.red(`\t  Error: ${error instanceof Error ? error.message : JSON.stringify(error)}`));
+      hasErrors = true;
+    }
+  }
+
+  if (hasErrors) {
+    exitWithCodeInvalidConfig();
+  }
+
+  return apiInformation;
+};
+
 const loadConfigBasedOnType = (options: CliOptions): object => {
+  // openApiSpecs cannot be combined with exact config parameters
+  if (options.openApiSpecs && exactConfigurationGroup.some(opt => options[opt as keyof CliOptions])) {
+    console.error(chalk.red('❌  You cannot use options from multiple configuration groups together.'));
+    console.error(chalk.red(`\tGroup 1: ${exactConfigurationGroup.join(', ')}`));
+    console.error(chalk.red('\tGroup 2: openApiSpecs'));
+    exitWithCodeInvalidConfig();
+  }
+
   const activeGroups = distinctConfigGroups.map(group => group.some(opt => options[opt as keyof CliOptions])).filter(Boolean);
 
   if (activeGroups.length > 1) {
@@ -147,41 +216,52 @@ const loadConfigBasedOnType = (options: CliOptions): object => {
     exitWithCodeInvalidConfig();
   }
 
+  let baseConfig: Partial<CalculateOptions>;
+
   if (activeGroups.length === 0) {
-    const fileConfig = validateConfigurationFromFile(resolveConfig()) as Partial<SanitizedOptions>;
-    return mergeWithCliOverrides(fileConfig, options);
-  }
-  if (options.configFile) {
-    const fileConfig = validateConfigurationFromFile(resolveConfig(options.configFile)) as Partial<SanitizedOptions>;
-    return mergeWithCliOverrides(fileConfig, options);
+    if (options.openApiSpecs) {
+      // Only openApiSpecs on CLI, no config file group — build base config from CLI options
+      baseConfig = mergeWithCliOverrides({}, options);
+    } else {
+      const fileConfig = validateConfigurationFromFile(resolveConfig()) as Partial<CalculateOptions>;
+      baseConfig = mergeWithCliOverrides(fileConfig, options);
+    }
+  } else if (options.configFile) {
+    const fileConfig = validateConfigurationFromFile(resolveConfig(options.configFile)) as Partial<CalculateOptions>;
+    baseConfig = mergeWithCliOverrides(fileConfig, options);
+  } else {
+    if (exactConfigurationGroup.some(opt => !Object.hasOwn(options, opt))) {
+      console.error(chalk.red('❌  Either define a config file or all of these calculation parameters:'));
+      exactConfigurationGroup.forEach(opt => console.error(chalk.red(`\t- --${opt.replaceAll(/([A-Z])/g, '-$1').toLowerCase()}`)));
+      exitWithCodeInvalidConfig();
+    }
+
+    const { apiName, apiVersion, async, lookbackWindow, qualityGate, serviceName, url } = options;
+    const attributeFilters = parseFilters(options.filter);
+
+    baseConfig = {
+      apiInformation: [{ apiName, apiVersion, serviceName }],
+      async: async ?? false,
+      attributeFilters,
+      lookbackWindow,
+      qualityGate,
+      url,
+    };
   }
 
+  // Apply openApiSpecs overlay: if apiInformation is already present it takes precedence
   if (options.openApiSpecs) {
-    // TODO: Load OpenAPI specs and merge them into options
-    console.warn(chalk.yellow('⚠️  OpenAPI specs are not yet implemented. Using provided options as is.'));
-    exit(0);
+    if (baseConfig.apiInformation && baseConfig.apiInformation.length > 0) {
+      console.warn(chalk.yellow('⚠️  --open-api-specs is ignored because apiInformation is already defined in the configuration.'));
+    } else {
+      baseConfig.apiInformation = loadApiInformationFromGlob(options);
+    }
   }
 
-  if (exactConfigurationGroup.some(opt => !Object.hasOwn(options, opt))) {
-    console.error(chalk.red('❌  Either define a config file or all of these calculation parameters:'));
-    exactConfigurationGroup.forEach(opt => console.error(chalk.red(`\t- --${opt.replaceAll(/([A-Z])/g, '-$1').toLowerCase()}`)));
-    exitWithCodeInvalidConfig();
-  }
-
-  const { apiName, apiVersion, async, lookbackWindow, qualityGate, serviceName, url } = options;
-  const attributeFilters = parseFilters(options.filter);
-
-  return {
-    apiInformation: [{ apiName, apiVersion, serviceName }],
-    async: async ?? false,
-    attributeFilters,
-    lookbackWindow,
-    qualityGate,
-    url,
-  };
+  return baseConfig;
 };
 
-export const validateConfiguration = (config: SanitizedOptions): SanitizedOptions => {
+export const validateConfiguration = (config: CalculateOptions): CalculateOptions => {
   if (!config.url) {
     console.error(chalk.red('❌  Snow-White base URL must be defined in the configuration.'));
     exitWithCodeInvalidConfig();
@@ -213,22 +293,12 @@ export const validateConfiguration = (config: SanitizedOptions): SanitizedOption
   return config;
 };
 
-export const sanitizeCalculateOptions = (options: CliOptions): SanitizedOptions => {
+export const sanitizeCalculateOptions = (options: CliOptions): CalculateOptions => {
   const config = loadConfigBasedOnType(options);
-  return validateConfiguration(config as SanitizedOptions);
+  return validateConfiguration(config as CalculateOptions);
 };
 
-export interface UploadCliOptions {
-  prereleaseSpecs: string;
-  url?: string;
-  configFile?: string;
-  apiNamePath?: string;
-  apiVersionPath?: string;
-  serviceNamePath?: string;
-  ignoreExisting?: boolean;
-}
-
-export const sanitizeUploadPrereleasesOptions = (options: UploadCliOptions): UploadPrereleasesOptions => {
+export const sanitizeUploadPrereleasesOptions = (options: CliOptions): UploadPrereleasesOptions => {
   let fileConfig: Partial<CliOptions> = {};
 
   // Load config file when explicitly requested or when URL is not provided via CLI

--- a/toolkit/cli/src/config/sanitize-configuration.ts
+++ b/toolkit/cli/src/config/sanitize-configuration.ts
@@ -138,12 +138,10 @@ const validateConfigurationFromFile = (options: CliOptions): CliOptions => {
   return options;
 };
 
-const loadApiInformationFromGlob = (options: CliOptions): ApiInformation[] => {
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const globPattern = options.openApiSpecs!;
-  const apiNamePath = options.apiNamePath ?? DEFAULT_API_NAME_PATH;
-  const apiVersionPath = options.apiVersionPath ?? DEFAULT_API_VERSION_PATH;
-  const serviceNamePath = options.serviceNamePath ?? DEFAULT_SERVICE_NAME_PATH;
+const loadApiInformationFromGlob = (globPattern: string, options: CliOptions, fileConfig: CliOptions): ApiInformation[] => {
+  const apiNamePath = options.apiNamePath ?? fileConfig.apiNamePath ?? DEFAULT_API_NAME_PATH;
+  const apiVersionPath = options.apiVersionPath ?? fileConfig.apiVersionPath ?? DEFAULT_API_VERSION_PATH;
+  const serviceNamePath = options.serviceNamePath ?? fileConfig.serviceNamePath ?? DEFAULT_SERVICE_NAME_PATH;
 
   const files = scanGlob(globPattern, process.cwd());
 
@@ -198,11 +196,11 @@ const loadApiInformationFromGlob = (options: CliOptions): ApiInformation[] => {
 };
 
 const loadConfigBasedOnType = (options: CliOptions): object => {
-  // openApiSpecs cannot be combined with exact config parameters
-  if (options.openApiSpecs && exactConfigurationGroup.some(opt => options[opt as keyof CliOptions])) {
+  // apiSpecs cannot be combined with exact config parameters
+  if (options.apiSpecs && exactConfigurationGroup.some(opt => options[opt as keyof CliOptions])) {
     console.error(chalk.red('❌  You cannot use options from multiple configuration groups together.'));
     console.error(chalk.red(`\tGroup 1: ${exactConfigurationGroup.join(', ')}`));
-    console.error(chalk.red('\tGroup 2: openApiSpecs'));
+    console.error(chalk.red('\tGroup 2: apiSpecs'));
     exitWithCodeInvalidConfig();
   }
 
@@ -216,19 +214,20 @@ const loadConfigBasedOnType = (options: CliOptions): object => {
     exitWithCodeInvalidConfig();
   }
 
+  let loadedFileOptions: Partial<CliOptions> | undefined;
   let baseConfig: Partial<CalculateOptions>;
 
   if (activeGroups.length === 0) {
-    if (options.openApiSpecs) {
-      // Only openApiSpecs on CLI, no config file group — build base config from CLI options
+    if (options.apiSpecs) {
+      // Only apiSpecs on CLI, no config file group — build base config from CLI options
       baseConfig = mergeWithCliOverrides({}, options);
     } else {
-      const fileConfig = validateConfigurationFromFile(resolveConfig()) as Partial<CalculateOptions>;
-      baseConfig = mergeWithCliOverrides(fileConfig, options);
+      loadedFileOptions = validateConfigurationFromFile(resolveConfig()) as unknown as Partial<CliOptions>;
+      baseConfig = mergeWithCliOverrides(loadedFileOptions as Partial<CalculateOptions>, options);
     }
   } else if (options.configFile) {
-    const fileConfig = validateConfigurationFromFile(resolveConfig(options.configFile)) as Partial<CalculateOptions>;
-    baseConfig = mergeWithCliOverrides(fileConfig, options);
+    loadedFileOptions = validateConfigurationFromFile(resolveConfig(options.configFile)) as unknown as Partial<CliOptions>;
+    baseConfig = mergeWithCliOverrides(loadedFileOptions as Partial<CalculateOptions>, options);
   } else {
     if (exactConfigurationGroup.some(opt => !Object.hasOwn(options, opt))) {
       console.error(chalk.red('❌  Either define a config file or all of these calculation parameters:'));
@@ -249,12 +248,20 @@ const loadConfigBasedOnType = (options: CliOptions): object => {
     };
   }
 
-  // Apply openApiSpecs overlay: if apiInformation is already present it takes precedence
-  if (options.openApiSpecs) {
+  // Resolve effective apiSpecs: CLI takes precedence over config file
+  const fileApiSpecs = loadedFileOptions?.apiSpecs;
+  const effectiveApiSpecs = options.apiSpecs ?? fileApiSpecs;
+
+  if (options.apiSpecs && fileApiSpecs && fileApiSpecs !== options.apiSpecs) {
+    console.warn(chalk.yellow(`⚠️  CLI parameter --api-specs overrides config file value: "${fileApiSpecs}" → "${options.apiSpecs}"`));
+  }
+
+  // Apply apiSpecs overlay: if apiInformation is already present it takes precedence
+  if (effectiveApiSpecs) {
     if (baseConfig.apiInformation && baseConfig.apiInformation.length > 0) {
-      console.warn(chalk.yellow('⚠️  --open-api-specs is ignored because apiInformation is already defined in the configuration.'));
+      console.warn(chalk.yellow('⚠️  --api-specs is ignored because apiInformation is already defined in the configuration.'));
     } else {
-      baseConfig.apiInformation = loadApiInformationFromGlob(options);
+      baseConfig.apiInformation = loadApiInformationFromGlob(effectiveApiSpecs, options, baseConfig);
     }
   }
 
@@ -301,8 +308,8 @@ export const sanitizeCalculateOptions = (options: CliOptions): CalculateOptions 
 export const sanitizeUploadPrereleasesOptions = (options: CliOptions): UploadPrereleasesOptions => {
   let fileConfig: Partial<CliOptions> = {};
 
-  // Load config file when explicitly requested or when URL is not provided via CLI
-  if (options.configFile || !options.url) {
+  // Load config file when explicitly requested, when URL is missing from CLI, or when apiSpecs is missing from CLI
+  if (options.configFile || !options.url || !options.apiSpecs) {
     fileConfig = resolveConfig(options.configFile) as Partial<CliOptions>;
   }
 
@@ -316,6 +323,19 @@ export const sanitizeUploadPrereleasesOptions = (options: CliOptions): UploadPre
 
   if (!url) {
     console.error(chalk.red('❌  Snow-White base URL must be defined via --url or in the configuration file.'));
+    exit(INVALID_CONFIG_FORMAT);
+  }
+
+  // apiSpecs: CLI takes precedence over config file
+  const fileApiSpecs = fileConfig.apiSpecs;
+  const apiSpecs = options.apiSpecs ?? fileApiSpecs;
+
+  if (options.apiSpecs && fileApiSpecs && fileApiSpecs !== options.apiSpecs) {
+    console.warn(chalk.yellow(`⚠️  CLI parameter --api-specs overrides config file value: "${fileApiSpecs}" → "${options.apiSpecs}"`));
+  }
+
+  if (!apiSpecs) {
+    console.error(chalk.red('❌  API specs glob pattern must be defined via --api-specs or in the configuration file.'));
     exit(INVALID_CONFIG_FORMAT);
   }
 
@@ -347,7 +367,7 @@ export const sanitizeUploadPrereleasesOptions = (options: CliOptions): UploadPre
   return {
     apiNamePath,
     apiVersionPath,
-    globPattern: options.prereleaseSpecs,
+    globPattern: apiSpecs,
     ignoreExisting: options.ignoreExisting ?? false,
     serviceNamePath,
     url,

--- a/toolkit/cli/src/config/sanitized-options.ts
+++ b/toolkit/cli/src/config/sanitized-options.ts
@@ -10,21 +10,21 @@ export interface ApiInformation {
   apiVersion: string;
 }
 
-export interface SanitizedOptions {
+export interface CalculateOptions {
   apiInformation: ApiInformation[];
+  async?: boolean;
+  attributeFilters?: Record<string, string>;
+  lookbackWindow?: string;
+  globPattern: string;
   qualityGate: string;
   url: string;
-  /**
-   * The time window to consider for calculation (e.g., '1h', '24h', '7d').
-   */
-  lookbackWindow?: string;
-  /**
-   * Key-value map of attributes to filter telemetry data.
-   */
-  attributeFilters?: Record<string, string>;
-  /**
-   * Fire-and-forget mode: skip polling for the calculation result.
-   * When false (default), the CLI polls until the calculation completes.
-   */
-  async?: boolean;
+}
+
+export interface UploadPrereleasesOptions {
+  globPattern: string;
+  url: string;
+  apiNamePath?: string;
+  apiVersionPath?: string;
+  serviceNamePath?: string;
+  ignoreExisting?: boolean;
 }

--- a/toolkit/cli/src/index.ts
+++ b/toolkit/cli/src/index.ts
@@ -45,7 +45,7 @@ program
   // Configuration from file, can contain all other configuration methods
   .option('--config-file <path>', 'Path to a YAML or JSON config file')
   // Read all OpenAPI specs matching the glob pattern
-  .option('--open-api-specs <pattern>', 'Glob pattern selecting which OpenAPI spec files to use')
+  .option('--api-specs <pattern>', 'Glob pattern selecting which OpenAPI spec files to use')
   .option('--api-name-path <jsonPath>', 'JSON path to the API name field in the specification (default: info.title)')
   .option('--api-version-path <jsonPath>', 'JSON path to the API version field in the specification (default: info.version)')
   .option('--service-name-path <jsonPath>', 'JSON path to the service name field in the specification (default: info.x-service-name)')
@@ -75,7 +75,7 @@ program
       'Intended to be called at the start of a pipeline before QA runs.\n' +
       'Uploaded prereleases are temporary and will be cleaned up asynchronously.',
   )
-  .requiredOption('--prerelease-specs <pattern>', 'Glob pattern selecting which specification files to upload (e.g. "services/**/openapi.yaml")')
+  .option('--api-specs <pattern>', 'Glob pattern selecting which specification files to upload (e.g. "services/**/openapi.yaml")')
   .option('--url <baseUrl>', 'Base URL for Snow-White (overrides config file)')
   .option('--config-file <path>', 'Path to config file (used to resolve --url if not provided directly)')
   .option('--api-name-path <jsonPath>', 'JSON path to the API name field in the specification')

--- a/toolkit/cli/src/index.ts
+++ b/toolkit/cli/src/index.ts
@@ -10,7 +10,6 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 
 import type { CliOptions } from './config/cli-options';
-import type {UploadCliOptions} from './config/sanitize-configuration';
 
 import { calculate } from './actions/calculate';
 import { uploadPrereleases } from './actions/upload-prereleases';
@@ -47,6 +46,9 @@ program
   .option('--config-file <path>', 'Path to a YAML or JSON config file')
   // Read all OpenAPI specs matching the glob pattern
   .option('--open-api-specs <pattern>', 'Glob pattern selecting which OpenAPI spec files to use')
+  .option('--api-name-path <jsonPath>', 'JSON path to the API name field in the specification (default: info.title)')
+  .option('--api-version-path <jsonPath>', 'JSON path to the API version field in the specification (default: info.version)')
+  .option('--service-name-path <jsonPath>', 'JSON path to the service name field in the specification (default: info.x-service-name)')
   // Explicit configuration for the Quality-Gate calculation
   .option('--quality-gate <name>', 'Quality-Gate configuration name')
   .option('--service-name <name>', 'Name of the service')
@@ -83,7 +85,7 @@ program
     'JSON path to the service name field in the specification (maps to the x-service-name extension in raw YAML)',
   )
   .option('--ignore-existing', 'Ignore previously indexed API specifications', false)
-  .action(async (options: UploadCliOptions) => {
+  .action(async (options: CliOptions) => {
     const sanitizedOptions = sanitizeUploadPrereleasesOptions(options);
     const apiIndexApi = getApiIndexApi(sanitizedOptions.url);
     await uploadPrereleases(apiIndexApi, sanitizedOptions);

--- a/toolkit/openapi-generator/pom.xml
+++ b/toolkit/openapi-generator/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>io.github.bbortt.snow-white.toolkit</groupId>
     <artifactId>toolkit</artifactId>
-    <version>1.0.0-SNAPSHOT-alpha.12</version>
+    <version>1.0.0-SNAPSHOT-alpha.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/toolkit/pom.xml
+++ b/toolkit/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>io.github.bbortt.snow-white</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0.0-SNAPSHOT-alpha.12</version>
+    <version>1.0.0-SNAPSHOT-alpha.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/toolkit/spring-web-autoconfiguration-it/pom.xml
+++ b/toolkit/spring-web-autoconfiguration-it/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>io.github.bbortt.snow-white.toolkit</groupId>
     <artifactId>toolkit</artifactId>
-    <version>1.0.0-SNAPSHOT-alpha.12</version>
+    <version>1.0.0-SNAPSHOT-alpha.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/toolkit/spring-web-autoconfiguration/pom.xml
+++ b/toolkit/spring-web-autoconfiguration/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>io.github.bbortt.snow-white.toolkit</groupId>
     <artifactId>toolkit</artifactId>
-    <version>1.0.0-SNAPSHOT-alpha.12</version>
+    <version>1.0.0-SNAPSHOT-alpha.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
MR introduces standardized cli argument `--api-specs` or config parameter `apiSpecs`.
this parameter accepts a glob pattern and can either be used...
* for api specification uploads with the `upload-prereleases` command or
* for coverage calculation with the `calculate` command.
because it is standardized, the "must be cli parameter" constraint has been removed from the `upload-prereleases` command.
the example `dev/snow-white.json` has been adjusted accordingly.