### PR TITLE
report status updates on errornous results

### DIFF
--- a/microservices/report-coordinator-api/src/main/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/service/QualityGateStatusCalculator.java
+++ b/microservices/report-coordinator-api/src/main/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/service/QualityGateStatusCalculator.java
@@ -7,23 +7,37 @@
 package io.github.bbortt.snow.white.microservices.report.coordinator.api.service;
 
 import static io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportStatus.FAILED;
+import static io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportStatus.FINISHED_EXCEPTIONALLY;
 import static io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportStatus.IN_PROGRESS;
 import static io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportStatus.NOT_STARTED;
 import static io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportStatus.PASSED;
+import static io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportStatus.TIMED_OUT;
 import static java.math.BigDecimal.ONE;
 import static org.springframework.util.CollectionUtils.isEmpty;
 
+import io.github.bbortt.snow.white.commons.testing.VisibleForTesting;
 import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ApiTestResult;
 import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.QualityGateReport;
+import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportStatus;
+import java.util.List;
 import org.springframework.stereotype.Component;
 
 @Component
 final class QualityGateStatusCalculator {
 
+  @VisibleForTesting
+  static final List<ReportStatus> TERMINAL_STATUS = List.of(
+    FAILED,
+    FINISHED_EXCEPTIONALLY,
+    TIMED_OUT
+  );
+
   QualityGateReport withUpdatedReportStatus(
     QualityGateReport qualityGateReport
   ) {
-    if (isEmpty(qualityGateReport.getApiTests())) {
+    if (TERMINAL_STATUS.contains(qualityGateReport.getReportStatus())) {
+      return qualityGateReport;
+    } else if (isEmpty(qualityGateReport.getApiTests())) {
       return qualityGateReport.withReportStatus(NOT_STARTED);
     } else if (
       qualityGateReport

--- a/microservices/report-coordinator-api/src/main/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/service/ReportService.java
+++ b/microservices/report-coordinator-api/src/main/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/service/ReportService.java
@@ -89,7 +89,8 @@ public class ReportService {
     var updated = report
       .withStackTrace(errorMessage)
       .withReportStatus(FINISHED_EXCEPTIONALLY);
-    update(updated);
+
+    updateWithStatusUpdate(updated);
   }
 
   private void handleSuccessfulResponse(
@@ -98,7 +99,6 @@ public class ReportService {
   ) {
     var qualityGateConfigName = report.getQualityGateConfigName();
 
-    final QualityGateReport updatedReport;
     try {
       var qualityGateConfig = qualityGateService.findQualityGateConfigByName(
         qualityGateConfigName
@@ -118,10 +118,6 @@ public class ReportService {
         apiTest,
         qualityGateConfig.getOpenApiCriteria()
       );
-
-      updatedReport = qualityGateStatusCalculator.withUpdatedReportStatus(
-        report
-      );
     } catch (QualityGateNotFoundException e) {
       logger.warn(
         "Cannot find quality-gate config: {}",
@@ -131,7 +127,7 @@ public class ReportService {
       return;
     }
 
-    update(updatedReport);
+    updateWithStatusUpdate(report);
   }
 
   @WithSpan
@@ -180,6 +176,13 @@ public class ReportService {
       .collect(toSet());
 
     return persistedReport.withApiTests(persistedApiTests);
+  }
+
+  private void updateWithStatusUpdate(QualityGateReport qualityGateReport) {
+    var qualityGateReportWithUpdatedStatus =
+      qualityGateStatusCalculator.withUpdatedReportStatus(qualityGateReport);
+
+    qualityGateReportRepository.save(qualityGateReportWithUpdatedStatus);
   }
 
   @WithSpan

--- a/microservices/report-coordinator-api/src/test/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/api/kafka/listener/OpenApiResultListenerIT.java
+++ b/microservices/report-coordinator-api/src/test/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/api/kafka/listener/OpenApiResultListenerIT.java
@@ -14,12 +14,15 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static io.github.bbortt.snow.white.commons.quality.gate.ApiType.OPENAPI;
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.ERROR_RESPONSE_CODE_COVERAGE;
 import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.HTTP_METHOD_COVERAGE;
 import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.PATH_COVERAGE;
 import static io.github.bbortt.snow.white.microservices.report.coordinator.api.TestData.defaultApiInformation;
 import static io.github.bbortt.snow.white.microservices.report.coordinator.api.TestData.defaultApiTest;
 import static io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportStatus.FAILED;
 import static io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportStatus.FINISHED_EXCEPTIONALLY;
+import static io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportStatus.IN_PROGRESS;
 import static io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportStatus.PASSED;
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.ZERO;
@@ -31,6 +34,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.awaitility.Awaitility.await;
 
 import io.github.bbortt.snow.white.commons.event.OpenApiCoverageResponseEvent;
+import io.github.bbortt.snow.white.commons.event.dto.ApiInformation;
 import io.github.bbortt.snow.white.commons.event.dto.OpenApiTestResult;
 import io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria;
 import io.github.bbortt.snow.white.microservices.report.coordinator.api.AbstractReportCoordinationServiceIT;
@@ -82,69 +86,29 @@ class OpenApiResultListenerIT extends AbstractReportCoordinationServiceIT {
   @Test
   void kafkaEvent_withCoveredCriteria_shouldBePersisted() {
     var calculationId = UUID.fromString("6fa77498-a7aa-48d2-8f1d-dee93eb45780");
-    var qualityGateConfigName = persistInitialQualityGateReport(calculationId);
+    var qualityGateReport = persistInitialQualityGateReport(calculationId);
 
-    var openApiCriterion = PATH_COVERAGE;
-    var qualityGateByNameEndpoint = createQualityGateApiWiremockStub(
-      qualityGateConfigName,
-      openApiCriterion
-    );
-
-    var duration = Duration.ofMillis(1234);
-    kafkaTemplate.send(
-      reportCoordinationServiceProperties
-        .getOpenapiCalculationResponse()
-        .getTopic(),
-      calculationId.toString(),
-      new OpenApiCoverageResponseEvent(
-        defaultApiInformation(),
-        Set.of(new OpenApiTestResult(openApiCriterion, ONE, duration))
-      )
-    );
-
-    assertThatEntityHasBeenUpdated(
+    sendAndVerifyOpenApiCoverageResponseEventWithOpenApiTestResult(
+      qualityGateReport.getQualityGateConfigName(),
+      PATH_COVERAGE,
       calculationId,
-      openApiCriterion,
-      PASSED,
-      ONE.setScale(2, HALF_UP),
-      duration
+      ONE,
+      PASSED
     );
-
-    verify(getRequestedFor(urlEqualTo(qualityGateByNameEndpoint)));
   }
 
   @Test
   void kafkaEvent_withUncoveredCriteria_shouldBePersisted() {
     var calculationId = UUID.fromString("dc296f73-8124-4bd3-bc09-5518bdb5be6e");
-    var qualityGateConfigName = persistInitialQualityGateReport(calculationId);
+    var qualityGateReport = persistInitialQualityGateReport(calculationId);
 
-    var openApiCriterion = HTTP_METHOD_COVERAGE;
-    var qualityGateByNameEndpoint = createQualityGateApiWiremockStub(
-      qualityGateConfigName,
-      openApiCriterion
-    );
-
-    var duration = Duration.ofMillis(1234);
-    kafkaTemplate.send(
-      reportCoordinationServiceProperties
-        .getOpenapiCalculationResponse()
-        .getTopic(),
-      calculationId.toString(),
-      new OpenApiCoverageResponseEvent(
-        defaultApiInformation(),
-        Set.of(new OpenApiTestResult(openApiCriterion, ZERO, duration))
-      )
-    );
-
-    assertThatEntityHasBeenUpdated(
+    sendAndVerifyOpenApiCoverageResponseEventWithOpenApiTestResult(
+      qualityGateReport.getQualityGateConfigName(),
+      HTTP_METHOD_COVERAGE,
       calculationId,
-      openApiCriterion,
-      FAILED,
-      ZERO.setScale(2, HALF_UP),
-      duration
+      ZERO,
+      FAILED
     );
-
-    verify(getRequestedFor(urlEqualTo(qualityGateByNameEndpoint)));
   }
 
   @Test
@@ -194,7 +158,71 @@ class OpenApiResultListenerIT extends AbstractReportCoordinationServiceIT {
     );
   }
 
-  private @NonNull String persistInitialQualityGateReport(UUID calculationId) {
+  @Test
+  void multipleKafkaEvents_withSameCalculationId_shouldBeAggregated() {
+    var calculationId = UUID.fromString("521f9236-369d-4cab-813a-98aa6e46b0a2");
+
+    var qualityGateReport = persistInitialQualityGateReport(calculationId);
+    var apiTest = apiTestRepository.save(
+      ApiTest.builder()
+        .serviceName("serviceName")
+        .apiName("otherApiName")
+        .apiVersion("apiVersion")
+        .apiType(OPENAPI.getVal())
+        .build()
+        .withQualityGateReport(qualityGateReport)
+    );
+
+    sendAndVerifyOpenApiCoverageResponseEventWithOpenApiTestResult(
+      qualityGateReport.getQualityGateConfigName(),
+      ERROR_RESPONSE_CODE_COVERAGE,
+      calculationId,
+      ONE,
+      IN_PROGRESS
+    );
+
+    kafkaTemplate.send(
+      reportCoordinationServiceProperties
+        .getOpenapiCalculationResponse()
+        .getTopic(),
+      calculationId.toString(),
+      new OpenApiCoverageResponseEvent(
+        ApiInformation.builder()
+          .serviceName(apiTest.getServiceName())
+          .apiName(apiTest.getApiName())
+          .apiVersion(apiTest.getApiVersion())
+          .apiType(OPENAPI)
+          .build(),
+        "Exception that should be persisted"
+      )
+    );
+
+    await()
+      .atMost(1, MINUTES)
+      .untilAsserted(
+        () -> qualityGateReportRepository.findById(calculationId),
+        persistedQualityGateReport ->
+          assertThat(persistedQualityGateReport)
+            .isPresent()
+            .get()
+            .satisfies(
+              report ->
+                assertThat(report.getReportStatus()).isEqualTo(
+                  FINISHED_EXCEPTIONALLY
+                ),
+              report ->
+                assertThat(report.getApiTests())
+                  .hasSize(2)
+                  .satisfiesOnlyOnce(persistedApiTest ->
+                    assertThat(persistedApiTest.getApiTestResults()).isEmpty()
+                  )
+            )
+      );
+  }
+
+  private @NonNull QualityGateReport persistInitialQualityGateReport(
+    UUID calculationId
+  ) {
     var qualityGateConfigName = "minimal";
     var qualityGateReport = qualityGateReportRepository.save(
       QualityGateReport.builder()
@@ -213,7 +241,42 @@ class OpenApiResultListenerIT extends AbstractReportCoordinationServiceIT {
       defaultApiTest().withQualityGateReport(qualityGateReport)
     );
 
-    return qualityGateConfigName;
+    return qualityGateReport;
+  }
+
+  private void sendAndVerifyOpenApiCoverageResponseEventWithOpenApiTestResult(
+    String qualityGateConfigName,
+    OpenApiCriteria openApiCriterion,
+    UUID calculationId,
+    BigDecimal one,
+    ReportStatus reportStatus
+  ) {
+    var qualityGateByNameEndpoint = createQualityGateApiWiremockStub(
+      qualityGateConfigName,
+      openApiCriterion
+    );
+
+    var duration = Duration.ofMillis(1234);
+    kafkaTemplate.send(
+      reportCoordinationServiceProperties
+        .getOpenapiCalculationResponse()
+        .getTopic(),
+      calculationId.toString(),
+      new OpenApiCoverageResponseEvent(
+        defaultApiInformation(),
+        Set.of(new OpenApiTestResult(openApiCriterion, one, duration))
+      )
+    );
+
+    assertThatEntityHasBeenUpdated(
+      calculationId,
+      openApiCriterion,
+      reportStatus,
+      one.setScale(2, HALF_UP),
+      duration
+    );
+
+    verify(getRequestedFor(urlEqualTo(qualityGateByNameEndpoint)));
   }
 
   private @NonNull String createQualityGateApiWiremockStub(
@@ -255,7 +318,7 @@ class OpenApiResultListenerIT extends AbstractReportCoordinationServiceIT {
                 assertThat(report.getReportStatus()).isEqualTo(reportStatus),
               report ->
                 assertThat(report.getApiTests())
-                  .hasSize(1)
+                  .hasSizeBetween(1, 2)
                   .first()
                   .extracting(ApiTest::getApiTestResults)
                   .asInstanceOf(SET)

--- a/microservices/report-coordinator-api/src/test/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/service/QualityGateStatusCalculatorTest.java
+++ b/microservices/report-coordinator-api/src/test/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/service/QualityGateStatusCalculatorTest.java
@@ -11,24 +11,32 @@ import static io.github.bbortt.snow.white.microservices.report.coordinator.api.d
 import static io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportStatus.IN_PROGRESS;
 import static io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportStatus.NOT_STARTED;
 import static io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportStatus.PASSED;
+import static io.github.bbortt.snow.white.microservices.report.coordinator.api.service.QualityGateStatusCalculator.TERMINAL_STATUS;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.ZERO;
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ApiTest;
 import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ApiTestResult;
 import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.QualityGateReport;
 import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportParameter;
+import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportStatus;
 import java.time.Duration;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class QualityGateStatusCalculatorTest {
 
@@ -195,6 +203,28 @@ class QualityGateStatusCalculatorTest {
       QualityGateReport result = fixture.withUpdatedReportStatus(report);
 
       assertThat(result.getReportStatus()).isEqualTo(PASSED);
+    }
+
+    public static Stream<
+      ReportStatus
+    > shouldReturnImmediately_whenReportStatusIsAlreadyTerminal() {
+      return TERMINAL_STATUS.stream();
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void shouldReturnImmediately_whenReportStatusIsAlreadyTerminal(
+      ReportStatus terminalStatus
+    ) {
+      var qualityGateReport = mock(QualityGateReport.class);
+      doReturn(terminalStatus).when(qualityGateReport).getReportStatus();
+
+      assertThat(fixture.withUpdatedReportStatus(qualityGateReport)).isEqualTo(
+        qualityGateReport
+      );
+
+      verify(qualityGateReport).getReportStatus();
+      verifyNoMoreInteractions(qualityGateReport);
     }
   }
 }

--- a/microservices/report-coordinator-api/src/test/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/service/ReportServiceTest.java
+++ b/microservices/report-coordinator-api/src/test/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/service/ReportServiceTest.java
@@ -227,6 +227,10 @@ class ReportServiceTest {
         .when(qualityGateReportRepositoryMock)
         .findById(CALCULATION_ID);
 
+      doAnswer(returnsFirstArg())
+        .when(qualityGateStatusCalculatorMock)
+        .withUpdatedReportStatus(any(QualityGateReport.class));
+
       var event = new OpenApiCoverageResponseEvent(
         mock(ApiInformation.class),
         "upstream failure"
@@ -238,14 +242,23 @@ class ReportServiceTest {
       verifyNoInteractions(qualityGateReportApiTestsFilterMock);
       verifyNoInteractions(apiTestResultMapperMock);
       verifyNoInteractions(apiTestResultLinkerMock);
-      verifyNoInteractions(qualityGateStatusCalculatorMock);
 
       ArgumentCaptor<QualityGateReport> reportCaptor = captor();
-      verify(qualityGateReportRepositoryMock).save(reportCaptor.capture());
+      verify(qualityGateStatusCalculatorMock).withUpdatedReportStatus(
+        reportCaptor.capture()
+      );
 
-      var saved = reportCaptor.getValue();
-      assertThat(saved.getReportStatus()).isEqualTo(FINISHED_EXCEPTIONALLY);
-      assertThat(saved.getStackTrace()).contains("upstream failure");
+      var qualityGateReportWithStackTrace = reportCaptor.getValue();
+      assertThat(qualityGateReportWithStackTrace.getReportStatus()).isEqualTo(
+        FINISHED_EXCEPTIONALLY
+      );
+      assertThat(qualityGateReportWithStackTrace.getStackTrace()).contains(
+        "upstream failure"
+      );
+
+      verify(qualityGateReportRepositoryMock).save(
+        qualityGateReportWithStackTrace
+      );
     }
 
     @Test
@@ -367,38 +380,6 @@ class ReportServiceTest {
           reportParameter
         )
       ).isEqualTo(cause);
-    }
-  }
-
-  @Nested
-  class HandleExceptionalResponseTest {
-
-    @Test
-    void shouldDelegateToRepositoryWithUpdatedStatus() {
-      var report = minimalQualityGateReport(
-        UUID.fromString("ed8d03da-5ee2-4852-b7cf-4e19c612bd62")
-      );
-      var errorMessage = "some error message";
-
-      fixture.handleExceptionalResponse(report, errorMessage);
-
-      ArgumentCaptor<QualityGateReport> qualityGateReportCaptor = captor();
-      verify(qualityGateReportRepositoryMock).save(
-        qualityGateReportCaptor.capture()
-      );
-
-      assertThat(qualityGateReportCaptor.getValue())
-        .isNotNull()
-        .satisfies(
-          qualityGateReport ->
-            assertThat(qualityGateReport.getReportStatus()).isEqualTo(
-              FINISHED_EXCEPTIONALLY
-            ),
-          qualityGateReport ->
-            assertThat(qualityGateReport.getStackTrace()).isEqualTo(
-              errorMessage
-            )
-        );
     }
   }
 


### PR DESCRIPTION
when multiple test results are being returned to `report-coordinator-api` (valid use case, when report includes multiple api specifications), the status calculation wasn't done right.
e.g. when `SUCCESS` and `FAILURE` "arrived", the overall status was resetted to `IN_PROGRESS`, because the failure doesn't include test results.
the `QualityGateStatusCalculator` has been adjusted accordingly.
tests have been added.