### PR TITLE
review openapi coverage variants

### DIFF
--- a/internal/commons/src/main/java/io/github/bbortt/snow/white/commons/quality/gate/OpenApiCriteria.java
+++ b/internal/commons/src/main/java/io/github/bbortt/snow/white/commons/quality/gate/OpenApiCriteria.java
@@ -34,6 +34,10 @@ public enum OpenApiCriteria {
     "Required Parameter Coverage",
     "Each required parameter (in path, query) has been tested with valid values. This is a subset of `PARAMETER_COVERAGE`."
   ),
+  OPTIONAL_PARAMETER_COVERAGE(
+    "Optional Parameter Coverage",
+    "Each optional (non-required) parameter (in path, query) has been tested with valid values. This is a subset of `PARAMETER_COVERAGE`."
+  ),
   PARAMETER_COVERAGE(
     "Parameter Coverage",
     "Each parameter (in path, query) has been tested with valid values."

--- a/internal/commons/src/main/java/io/github/bbortt/snow/white/commons/quality/gate/OpenApiCriteria.java
+++ b/internal/commons/src/main/java/io/github/bbortt/snow/white/commons/quality/gate/OpenApiCriteria.java
@@ -22,6 +22,10 @@ public enum OpenApiCriteria {
     "Error Response Code Coverage",
     "Each documented error response code for each endpoint is tested. This is a subset of `RESPONSE_CODE_COVERAGE`."
   ),
+  POSITIVE_RESPONSE_CODE_COVERAGE(
+    "Positive Response Code Coverage",
+    "Each documented positive (non-error) response code (1xx, 2xx, 3xx) for each endpoint is tested. This is a subset of `RESPONSE_CODE_COVERAGE`."
+  ),
   RESPONSE_CODE_COVERAGE(
     "Response Code Coverage",
     "Each documented response code for each endpoint is tested."

--- a/internal/commons/src/main/java/io/github/bbortt/snow/white/commons/quality/gate/OpenApiCriteria.java
+++ b/internal/commons/src/main/java/io/github/bbortt/snow/white/commons/quality/gate/OpenApiCriteria.java
@@ -18,6 +18,10 @@ public enum OpenApiCriteria {
     "HTTP Method Coverage",
     "Each HTTP method (`GET`, `POST`, `PUT`, `DELETE`, etc.) for each path has been tested."
   ),
+  OPERATION_SUCCESS_COVERAGE(
+    "Operation Success Coverage",
+    "Each operation (unique path + HTTP method combination) has produced at least one successful (2xx) response. Complements `HTTP_METHOD_COVERAGE`, which only checks that an operation was called at all."
+  ),
   ERROR_RESPONSE_CODE_COVERAGE(
     "Error Response Code Coverage",
     "Each documented error response code for each endpoint is tested. This is a subset of `RESPONSE_CODE_COVERAGE`."

--- a/internal/commons/src/main/java/io/github/bbortt/snow/white/commons/quality/gate/OpenApiCriteria.java
+++ b/internal/commons/src/main/java/io/github/bbortt/snow/white/commons/quality/gate/OpenApiCriteria.java
@@ -42,6 +42,10 @@ public enum OpenApiCriteria {
     "Parameter Coverage",
     "Each parameter (in path, query) has been tested with valid values."
   ),
+  CONTENT_TYPE_COVERAGE(
+    "Content Type Coverage",
+    "Each documented request body content type (e.g. `application/json`, `multipart/form-data`) for each endpoint has been exercised."
+  ),
   REQUIRED_ERROR_FIELDS_COVERAGE(
     "Required Error Fields Coverage",
     "Error responses include all required fields."

--- a/microservices/api-gateway/src/main/webapp/app/entities/quality-gate/api-test-card.scss
+++ b/microservices/api-gateway/src/main/webapp/app/entities/quality-gate/api-test-card.scss
@@ -7,3 +7,29 @@
 .mouse-hover-pointer {
   cursor: pointer;
 }
+
+.row-fade-enter {
+  opacity: 0;
+  transform: translateY(-6px);
+}
+
+.row-fade-enter-active {
+  opacity: 1;
+  transform: translateY(0);
+  transition:
+    opacity 200ms ease,
+    transform 200ms ease;
+}
+
+.row-fade-exit {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.row-fade-exit-active {
+  opacity: 0;
+  transform: translateY(6px);
+  transition:
+    opacity 200ms ease,
+    transform 200ms ease;
+}

--- a/microservices/api-gateway/src/main/webapp/app/entities/quality-gate/api-test-card.tsx
+++ b/microservices/api-gateway/src/main/webapp/app/entities/quality-gate/api-test-card.tsx
@@ -6,6 +6,7 @@
 
 import './api-test-card.scss';
 
+import type { IApiTestResult } from 'app/shared/model/api-test-result.model';
 import type { IApiTest } from 'app/shared/model/api-test.model';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -21,6 +22,7 @@ import { v4 as uuidv4 } from 'uuid';
 interface ApiTestCardProps {
   apiTest: IApiTest;
   qualityGateStatus: ReportStatus;
+  showOnlyIncluded: boolean;
 }
 
 const isQualityGateStatusOverride = (qualityGateStatus: ReportStatus): boolean => {
@@ -37,7 +39,7 @@ const renderStatusBadge = (containsTestResults: boolean, testResultsPassed: bool
   return <StatusBadge status={ReportStatus.FAILED} />;
 };
 
-export const ApiTestCard: React.FC<ApiTestCardProps> = ({ apiTest, qualityGateStatus }: ApiTestCardProps) => {
+export const ApiTestCard: React.FC<ApiTestCardProps> = ({ apiTest, qualityGateStatus, showOnlyIncluded }: ApiTestCardProps) => {
   const apiTestResultStatus = useMemo(
     () =>
       !apiTest.testResults
@@ -53,6 +55,11 @@ export const ApiTestCard: React.FC<ApiTestCardProps> = ({ apiTest, qualityGateSt
 
   const [tooltipOpen, setTooltipOpen] = useState(false);
   const toggleTooltip = () => setTooltipOpen(!tooltipOpen);
+
+  const visibleTestResults: IApiTestResult[] = useMemo(
+    () => (showOnlyIncluded ? (apiTest.testResults ?? []).filter(r => r.isIncludedInQualityGate) : (apiTest.testResults ?? [])),
+    [apiTest.testResults, showOnlyIncluded],
+  );
 
   return (
     <Card>
@@ -99,7 +106,7 @@ export const ApiTestCard: React.FC<ApiTestCardProps> = ({ apiTest, qualityGateSt
       <CardBody>
         <Collapse isOpen={isOpen}>
           {containsTestResults ? (
-            <ApiTestResultTable apiTestResults={apiTest.testResults!} />
+            <ApiTestResultTable apiTestResults={visibleTestResults} />
           ) : (
             <div className="alert alert-warning">
               <Translate contentKey="snowWhiteApp.apiTestResult.home.notFound">No API Test Results found</Translate>

--- a/microservices/api-gateway/src/main/webapp/app/entities/quality-gate/api-test-card.tsx
+++ b/microservices/api-gateway/src/main/webapp/app/entities/quality-gate/api-test-card.tsx
@@ -39,7 +39,10 @@ const renderStatusBadge = (containsTestResults: boolean, testResultsPassed: bool
 
 export const ApiTestCard: React.FC<ApiTestCardProps> = ({ apiTest, qualityGateStatus }: ApiTestCardProps) => {
   const apiTestResultStatus = useMemo(
-    () => !apiTest.testResults?.some(apiTestResult => !apiTestResult.coverage || apiTestResult.coverage < 1) || false,
+    () =>
+      !apiTest.testResults
+        ?.filter(apiTestResult => apiTestResult.isIncludedInQualityGate)
+        .some(apiTestResult => !apiTestResult.coverage || apiTestResult.coverage < 1) || false,
     [apiTest.testResults],
   );
   const containsTestResults = useMemo(() => (apiTest.testResults && apiTest.testResults.length > 0) || false, [apiTest.testResults]);

--- a/microservices/api-gateway/src/main/webapp/app/entities/quality-gate/api-test-result-table.tsx
+++ b/microservices/api-gateway/src/main/webapp/app/entities/quality-gate/api-test-result-table.tsx
@@ -11,8 +11,9 @@ import { getEntities } from 'app/entities/open-api-criterion/open-api-criterion.
 import ApiCriterionInfo from 'app/entities/quality-gate/api-criterion-info';
 import { IOpenApiCriterion } from 'app/shared/model/open-api-criterion.model';
 import { TextWithCode } from 'app/shared/TextWithCode';
-import React, { useEffect, useMemo } from 'react';
+import React, { createRef, useEffect, useMemo, useRef } from 'react';
 import { translate, Translate } from 'react-jhipster';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { Table } from 'reactstrap';
 
 interface ApiTestResultTableProps {
@@ -24,52 +25,54 @@ export const ApiTestResultTable: React.FC<ApiTestResultTableProps> = ({ apiTestR
 
   const openApiCriterionList: IOpenApiCriterion[] | undefined = useAppSelector(state => state.snowwhite.openApiCriterion.entities);
 
-  const getAllEntities = () => {
-    dispatch(getEntities());
-  };
-
-  const handleSyncList = () => {
-    getAllEntities();
-  };
+  const nodeRefs = useRef<Map<string, React.RefObject<HTMLTableRowElement | null>>>(new Map());
 
   useEffect(() => {
-    handleSyncList();
+    dispatch(getEntities());
   }, []);
 
   const tableBody = useMemo(() => {
     if (!openApiCriterionList || openApiCriterionList.length === 0) {
-      return <></>;
+      return null;
     }
 
     return apiTestResults
       .slice()
       .sort((a, b) => a.id!.localeCompare(b.id!))
-      .map((apiTestResult: IApiTestResult) => {
+      .flatMap((apiTestResult: IApiTestResult) => {
         const apiCriterion: IOpenApiCriterion | undefined = openApiCriterionList.find(
           (criterion: IOpenApiCriterion) => criterion.name === apiTestResult.id,
         );
 
         if (!apiCriterion) {
-          return <></>;
+          return [];
         }
+
+        const key = `entity-${apiTestResult.id}`;
+        if (!nodeRefs.current.has(key)) {
+          nodeRefs.current.set(key, createRef<HTMLTableRowElement>());
+        }
+        const nodeRef = nodeRefs.current.get(key)!;
 
         const nameText = translate(`snowWhiteApp.openApiCriterion.description.${apiCriterion.name}.name`);
 
-        return (
-          <tr key={`entity-${apiTestResult.id}`} data-cy="apiTestResultTable">
-            <td>{nameText}</td>
-            <td>
-              <ApiCriterionInfo apiCriterion={apiCriterion} />
-            </td>
-            <td>{apiTestResult.coverage}</td>
-            <td>{String(apiTestResult.isIncludedInQualityGate)}</td>
-            <td>
-              <TextWithCode text={apiTestResult.additionalInformation} />
-            </td>
-          </tr>
-        );
+        return [
+          <CSSTransition key={key} timeout={200} classNames="row-fade" nodeRef={nodeRef}>
+            <tr ref={nodeRef} data-cy="apiTestResultTable">
+              <td>{nameText}</td>
+              <td>
+                <ApiCriterionInfo apiCriterion={apiCriterion} />
+              </td>
+              <td>{apiTestResult.coverage}</td>
+              <td>{String(apiTestResult.isIncludedInQualityGate)}</td>
+              <td>
+                <TextWithCode text={apiTestResult.additionalInformation} />
+              </td>
+            </tr>
+          </CSSTransition>,
+        ];
       });
-  }, [openApiCriterionList]);
+  }, [openApiCriterionList, apiTestResults]);
 
   return (
     <div>
@@ -92,7 +95,7 @@ export const ApiTestResultTable: React.FC<ApiTestResultTableProps> = ({ apiTestR
               </th>
             </tr>
           </thead>
-          <tbody>{tableBody}</tbody>
+          <TransitionGroup component="tbody">{tableBody}</TransitionGroup>
         </Table>
       </div>
     </div>

--- a/microservices/api-gateway/src/main/webapp/app/entities/quality-gate/quality-gate-detail.tsx
+++ b/microservices/api-gateway/src/main/webapp/app/entities/quality-gate/quality-gate-detail.tsx
@@ -12,10 +12,10 @@ import { useAppDispatch, useAppSelector } from 'app/config/store';
 import { ApiTestCard } from 'app/entities/quality-gate/api-test-card';
 import { QualityGateSummary } from 'app/entities/quality-gate/quality-gate-summary';
 import { ReportStatus } from 'app/shared/model/enumerations/report-status.model';
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Translate } from 'react-jhipster';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { Button, Col, Row } from 'reactstrap';
+import { Button, Col, FormGroup, Input, Label, Row } from 'reactstrap';
 
 import { getEntity } from './quality-gate.reducer';
 
@@ -36,6 +36,8 @@ export const QualityGateDetail = () => {
   const loading = useAppSelector(state => state.snowwhite.qualityGate.loading);
   const qualityGateEntity: IQualityGate = useAppSelector(state => state.snowwhite.qualityGate.entity);
 
+  const [showOnlyIncluded, setShowOnlyIncluded] = useState(true);
+
   const sortedApiTests: IApiTest[] = useMemo(
     () =>
       [...(qualityGateEntity.apiTests ?? [])].sort(
@@ -55,14 +57,29 @@ export const QualityGateDetail = () => {
         </h2>
         <QualityGateSummary qualityGate={qualityGateEntity} />
         <hr className="mt-5" />
-        <h3 className="mb-2">
-          <Translate contentKey="snowWhiteApp.apiTestResult.home.title">API Test Results</Translate>
-        </h3>
+        <div className="d-flex align-items-center justify-content-between mb-2">
+          <h3 className="mb-0">
+            <Translate contentKey="snowWhiteApp.apiTestResult.home.title">API Test Results</Translate>
+          </h3>
+          <FormGroup switch className="mb-0">
+            <Input
+              type="switch"
+              role="switch"
+              id="filter-included-switch"
+              checked={showOnlyIncluded}
+              onChange={() => setShowOnlyIncluded(prev => !prev)}
+            />
+            <Label check htmlFor="filter-included-switch">
+              <Translate contentKey="snowWhiteApp.apiTestResult.showOnlyIncluded">Show only included</Translate>
+            </Label>
+          </FormGroup>
+        </div>
         {qualityGateEntity.apiTests && qualityGateEntity.apiTests.length > 0
           ? sortedApiTests.map((apiTest: IApiTest) => (
               <ApiTestCard
                 apiTest={apiTest}
                 qualityGateStatus={qualityGateEntity.status || ReportStatus.NOT_STARTED}
+                showOnlyIncluded={showOnlyIncluded}
                 key={`api-test-${apiTest.serviceName}-${apiTest.apiName}-${apiTest.apiVersion}`}
               />
             ))

--- a/microservices/api-gateway/src/main/webapp/app/entities/quality-gate/quality-gate-detail.tsx
+++ b/microservices/api-gateway/src/main/webapp/app/entities/quality-gate/quality-gate-detail.tsx
@@ -4,21 +4,16 @@
  * See LICENSE file for full details.
  */
 
-import type { IApiTestResult } from 'app/shared/model/api-test-result.model';
 import type { IApiTest } from 'app/shared/model/api-test.model';
 import type { IQualityGate } from 'app/shared/model/quality-gate.model';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { APP_DATE_FORMAT } from 'app/config/constants';
 import { useAppDispatch, useAppSelector } from 'app/config/store';
 import { ApiTestCard } from 'app/entities/quality-gate/api-test-card';
-import { CodeHighlightBlock } from 'app/entities/quality-gate/code-highlight-block';
-import { ShapePieChart } from 'app/entities/quality-gate/shape-pie-chart';
-import { StackTraceCard } from 'app/entities/quality-gate/stack-trace-card';
-import { StatusBadge } from 'app/entities/quality-gate/status-badge';
+import { QualityGateSummary } from 'app/entities/quality-gate/quality-gate-summary';
 import { ReportStatus } from 'app/shared/model/enumerations/report-status.model';
 import React, { useEffect, useMemo } from 'react';
-import { TextFormat, Translate } from 'react-jhipster';
+import { Translate } from 'react-jhipster';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { Button, Col, Row } from 'reactstrap';
 
@@ -45,9 +40,9 @@ export const QualityGateDetail = () => {
     () =>
       [...(qualityGateEntity.apiTests ?? [])].sort(
         (a, b) =>
-          (a.serviceName ?? '').localeCompare(b.serviceName ?? '') ||
-          (a.apiName ?? '').localeCompare(b.apiName ?? '') ||
-          (a.apiVersion ?? '').localeCompare(b.apiVersion ?? ''),
+          compareNullable(a.serviceName, b.serviceName) ||
+          compareNullable(a.apiName, b.apiName) ||
+          compareNullable(a.apiVersion, b.apiVersion),
       ),
     [qualityGateEntity],
   );
@@ -56,106 +51,26 @@ export const QualityGateDetail = () => {
     <Row>
       <Col>
         <h2 data-cy="qualityGateDetailsHeading">
-          <Translate contentKey="snowWhiteApp.qualityGate.detail.title">QualityGate</Translate>
+          <Translate contentKey="snowWhiteApp.qualityGate.detail.title">Quality-Gate Result</Translate>
         </h2>
-        <dl className="jh-entity-details">
-          <dd>
-            <Row>
-              <Col md={6}>
-                <dl className="jh-entity-details">
-                  <dt>
-                    <span id="calculationId">
-                      <Translate contentKey="snowWhiteApp.qualityGate.calculationId">Calculation Id</Translate>
-                    </span>
-                  </dt>
-                  <dd>{qualityGateEntity.calculationId}</dd>
-                  <dt>
-                    <span id="qualityGateConfigName">
-                      <Translate contentKey="snowWhiteApp.qualityGate.qualityGateConfigName">Quality-Gate</Translate>
-                    </span>
-                  </dt>
-                  <dd>
-                    <Button tag={Link} to={`/quality-gate-config/${qualityGateEntity.qualityGateConfig?.name}`} color="link" size="sm">
-                      {qualityGateEntity.qualityGateConfig?.name}
-                    </Button>
-                  </dd>
-                  <dt>
-                    <span id="status">
-                      <Translate contentKey="snowWhiteApp.qualityGate.status">Status</Translate>
-                    </span>
-                  </dt>
-                  <dd>
-                    <StatusBadge status={qualityGateEntity.status || ReportStatus.NOT_STARTED} />
-                  </dd>
-                  <dt>
-                    <span id="createdAt">
-                      <Translate contentKey="snowWhiteApp.qualityGate.createdAt">Created At</Translate>
-                    </span>
-                  </dt>
-                  <dd>
-                    {qualityGateEntity.createdAt ? (
-                      <TextFormat value={qualityGateEntity.createdAt} type="date" format={APP_DATE_FORMAT} />
-                    ) : null}
-                  </dd>
-                  {qualityGateEntity.stackTrace ? <StackTraceCard stackTrace={qualityGateEntity.stackTrace} /> : null}
-                  <dt>
-                    <Translate contentKey="snowWhiteApp.qualityGate.calculationRequest">Calculation Request</Translate>
-                  </dt>
-                  <dd>
-                    {qualityGateEntity.calculationRequest ? (
-                      <CodeHighlightBlock code={JSON.stringify(qualityGateEntity.calculationRequest)} language="json" />
-                    ) : (
-                      ''
-                    )}
-                  </dd>
-                </dl>
-              </Col>
-              <Col md={3}>
-                <h3 className="text-center" data-cy="qualityGateResultsHeading">
-                  <Translate contentKey="snowWhiteApp.qualityGate.shapes.qualityGateResults">Included Criteria Status</Translate>
-                </h3>
-                <ShapePieChart
-                  apiTestResults={(qualityGateEntity.apiTests?.flatMap((apiTest: IApiTest) => apiTest.testResults ?? []) ?? [])
-                    .slice()
-                    .filter((apiTestResult: IApiTestResult) => apiTestResult.isIncludedInQualityGate)}
-                />
-              </Col>
-              <Col md={3}>
-                <h3 className="text-center" data-cy="allResultsHeading">
-                  <Translate contentKey="snowWhiteApp.qualityGate.shapes.allResults">All Criteria Status</Translate>
-                </h3>
-                <ShapePieChart
-                  apiTestResults={qualityGateEntity.apiTests?.flatMap((apiTest: IApiTest) => apiTest.testResults ?? []) ?? []}
-                />
-              </Col>
-            </Row>
-          </dd>
-          <hr className="mt-5" />
-          <dt>
-            <h3 className="mb-2">
-              <Translate contentKey="snowWhiteApp.apiTestResult.home.title">API Test Results</Translate>
-            </h3>
-          </dt>
-          <dd>
-            {qualityGateEntity.apiTests && qualityGateEntity.apiTests.length > 0 ? (
-              <>
-                {sortedApiTests.map((apiTest: IApiTest) => (
-                  <ApiTestCard
-                    apiTest={apiTest}
-                    qualityGateStatus={qualityGateEntity.status || ReportStatus.NOT_STARTED}
-                    key={`api-test-${apiTest.serviceName}-${apiTest.apiName}-${apiTest.apiVersion}`}
-                  />
-                ))}
-              </>
-            ) : (
-              !loading && (
-                <div className="alert alert-warning">
-                  <Translate contentKey="snowWhiteApp.qualityGate.home.notFound">No Quality Gates found</Translate>
-                </div>
-              )
+        <QualityGateSummary qualityGate={qualityGateEntity} />
+        <hr className="mt-5" />
+        <h3 className="mb-2">
+          <Translate contentKey="snowWhiteApp.apiTestResult.home.title">API Test Results</Translate>
+        </h3>
+        {qualityGateEntity.apiTests && qualityGateEntity.apiTests.length > 0
+          ? sortedApiTests.map((apiTest: IApiTest) => (
+              <ApiTestCard
+                apiTest={apiTest}
+                qualityGateStatus={qualityGateEntity.status || ReportStatus.NOT_STARTED}
+                key={`api-test-${apiTest.serviceName}-${apiTest.apiName}-${apiTest.apiVersion}`}
+              />
+            ))
+          : !loading && (
+              <div className="alert alert-warning">
+                <Translate contentKey="snowWhiteApp.qualityGate.home.notFound">No Quality Gates found</Translate>
+              </div>
             )}
-          </dd>
-        </dl>
         <Button tag={Link} onClick={() => navigate(-1)} replace color="info" data-cy="entityDetailsBackButton">
           <FontAwesomeIcon icon="arrow-left" />{' '}
           <span className="d-none d-md-inline">

--- a/microservices/api-gateway/src/main/webapp/app/entities/quality-gate/quality-gate-summary.tsx
+++ b/microservices/api-gateway/src/main/webapp/app/entities/quality-gate/quality-gate-summary.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Timon Borter <timon.borter@gmx.ch>
+ * Licensed under the Polyform Small Business License 1.0.0
+ * See LICENSE file for full details.
+ */
+
+import type { IApiTestResult } from 'app/shared/model/api-test-result.model';
+import type { IApiTest } from 'app/shared/model/api-test.model';
+import type { IQualityGate } from 'app/shared/model/quality-gate.model';
+
+import { APP_DATE_FORMAT } from 'app/config/constants';
+import { CodeHighlightBlock } from 'app/entities/quality-gate/code-highlight-block';
+import { ShapePieChart } from 'app/entities/quality-gate/shape-pie-chart';
+import { StackTraceCard } from 'app/entities/quality-gate/stack-trace-card';
+import { StatusBadge } from 'app/entities/quality-gate/status-badge';
+import { ReportStatus } from 'app/shared/model/enumerations/report-status.model';
+import React from 'react';
+import { TextFormat, Translate } from 'react-jhipster';
+import { Link } from 'react-router-dom';
+import { Button, Col, Row } from 'reactstrap';
+
+interface QualityGateSummaryProps {
+  qualityGate: IQualityGate;
+}
+
+export const QualityGateSummary: React.FC<QualityGateSummaryProps> = ({ qualityGate }) => {
+  const allResults: IApiTestResult[] = qualityGate.apiTests?.flatMap((apiTest: IApiTest) => apiTest.testResults ?? []) ?? [];
+
+  return (
+    <Row>
+      <Col md={6}>
+        <dl className="jh-entity-details">
+          <dt>
+            <span id="calculationId">
+              <Translate contentKey="snowWhiteApp.qualityGate.calculationId">Calculation Id</Translate>
+            </span>
+          </dt>
+          <dd>{qualityGate.calculationId}</dd>
+          <dt>
+            <span id="qualityGateConfigName">
+              <Translate contentKey="snowWhiteApp.qualityGate.qualityGateConfigName">Quality-Gate</Translate>
+            </span>
+          </dt>
+          <dd>
+            <Button tag={Link} to={`/quality-gate-config/${qualityGate.qualityGateConfig?.name}`} color="link" size="sm">
+              {qualityGate.qualityGateConfig?.name}
+            </Button>
+          </dd>
+          <dt>
+            <span id="status">
+              <Translate contentKey="snowWhiteApp.qualityGate.status">Status</Translate>
+            </span>
+          </dt>
+          <dd>
+            <StatusBadge status={qualityGate.status || ReportStatus.NOT_STARTED} />
+          </dd>
+          <dt>
+            <span id="createdAt">
+              <Translate contentKey="snowWhiteApp.qualityGate.createdAt">Created At</Translate>
+            </span>
+          </dt>
+          <dd>{qualityGate.createdAt ? <TextFormat value={qualityGate.createdAt} type="date" format={APP_DATE_FORMAT} /> : null}</dd>
+          {qualityGate.stackTrace ? <StackTraceCard stackTrace={qualityGate.stackTrace} /> : null}
+          <dt>
+            <Translate contentKey="snowWhiteApp.qualityGate.calculationRequest">Calculation Request</Translate>
+          </dt>
+          <dd>
+            {qualityGate.calculationRequest ? (
+              <CodeHighlightBlock code={JSON.stringify(qualityGate.calculationRequest)} language="json" />
+            ) : (
+              ''
+            )}
+          </dd>
+        </dl>
+      </Col>
+      <Col md={3}>
+        <h3 className="text-center" data-cy="qualityGateResultsHeading">
+          <Translate contentKey="snowWhiteApp.qualityGate.shapes.qualityGateResults">Included Criteria Status</Translate>
+        </h3>
+        <ShapePieChart apiTestResults={allResults.filter((r: IApiTestResult) => r.isIncludedInQualityGate)} />
+      </Col>
+      <Col md={3}>
+        <h3 className="text-center" data-cy="allResultsHeading">
+          <Translate contentKey="snowWhiteApp.qualityGate.shapes.allResults">All Criteria Status</Translate>
+        </h3>
+        <ShapePieChart apiTestResults={allResults} />
+      </Col>
+    </Row>
+  );
+};
+
+export default QualityGateSummary;

--- a/microservices/api-gateway/src/main/webapp/i18n/de/apiTestResult.json
+++ b/microservices/api-gateway/src/main/webapp/i18n/de/apiTestResult.json
@@ -12,6 +12,7 @@
       "id": "API Kriterium",
       "coverage": "Abdeckung der inkludierten Kriterien",
       "isIncludedInQualityGate": "In Quality-Gate inkludiert?",
+      "showOnlyIncluded": "Nur inkludierte anzeigen",
       "additionalInformation": "Details",
       "qualityGate": "Quality-Gate"
     }

--- a/microservices/api-gateway/src/main/webapp/i18n/de/openApiCriterion.json
+++ b/microservices/api-gateway/src/main/webapp/i18n/de/openApiCriterion.json
@@ -21,9 +21,17 @@
           "name": "HTTP Methode",
           "description": "Jede HTTP-Methode (`GET`, `POST`, `PUT`, `DELETE`, etc.) für jeden Pfad wurde getestet."
         },
+        "OPERATION_SUCCESS_COVERAGE": {
+          "name": "Erfolgreiche Operation",
+          "description": "Jede Operation (eindeutige Pfad- und HTTP-Methoden-Kombination) hat mindestens eine erfolgreiche (2xx) Antwort erzeugt. Ergänzt `HTTP_METHOD_COVERAGE`, das nur prüft, ob eine Operation überhaupt aufgerufen wurde."
+        },
         "ERROR_RESPONSE_CODE_COVERAGE": {
           "name": "Fehler Antwort-Code",
           "description": "Jeder dokumentierte Fehlerantwortcode für jeden Endpunkt wurde getestet. Dies ist eine Teilmenge von `RESPONSE_CODE_COVERAGE`."
+        },
+        "POSITIVE_RESPONSE_CODE_COVERAGE": {
+          "name": "Positiver Antwort-Code",
+          "description": "Jeder dokumentierte positive (nicht-fehlerhafte) Antwortcode (1xx, 2xx, 3xx) für jeden Endpunkt wurde getestet. Dies ist eine Teilmenge von `RESPONSE_CODE_COVERAGE`."
         },
         "RESPONSE_CODE_COVERAGE": {
           "name": "Antwort-Code",
@@ -33,9 +41,17 @@
           "name": "Erforderlicher Parameter",
           "description": "Jeder erforderliche Parameter (in path, query) wurde mit gültigen Werten getestet. Dies ist eine Teilmenge von `PARAMETER_COVERAGE`."
         },
+        "OPTIONAL_PARAMETER_COVERAGE": {
+          "name": "Optionaler Parameter",
+          "description": "Jeder optionale (nicht erforderliche) Parameter (in path, query) wurde mit gültigen Werten getestet. Dies ist eine Teilmenge von `PARAMETER_COVERAGE`."
+        },
         "PARAMETER_COVERAGE": {
           "name": "Parameter",
           "description": "Jeder Parameter (in path, query) wurde mit gültigen Werten getestet."
+        },
+        "CONTENT_TYPE_COVERAGE": {
+          "name": "Content-Type",
+          "description": "Jeder dokumentierte Content-Type des Request-Body (z.B. `application/json`, `multipart/form-data`) für jeden Endpunkt wurde verwendet."
         },
         "REQUIRED_ERROR_FIELDS_COVERAGE": {
           "name": "Erfoderliche Fehler-Felder",

--- a/microservices/api-gateway/src/main/webapp/i18n/en/apiTestResult.json
+++ b/microservices/api-gateway/src/main/webapp/i18n/en/apiTestResult.json
@@ -12,6 +12,7 @@
       "id": "API Criterion",
       "coverage": "Coverage of included Criteria",
       "isIncludedInQualityGate": "Included in Quality-Gate?",
+      "showOnlyIncluded": "Show only included",
       "additionalInformation": "Details",
       "qualityGate": "Quality-Gate"
     }

--- a/microservices/api-gateway/src/main/webapp/i18n/en/openApiCriterion.json
+++ b/microservices/api-gateway/src/main/webapp/i18n/en/openApiCriterion.json
@@ -21,9 +21,17 @@
           "name": "HTTP Method",
           "description": "Each HTTP method (`GET`, `POST`, `PUT`, `DELETE`, etc.) for each path has been tested."
         },
+        "OPERATION_SUCCESS_COVERAGE": {
+          "name": "Operation Success",
+          "description": "Each operation (unique path + HTTP method combination) has produced at least one successful (2xx) response. Complements `HTTP_METHOD_COVERAGE`, which only checks that an operation was called at all."
+        },
         "ERROR_RESPONSE_CODE_COVERAGE": {
           "name": "Error Response Code",
           "description": "Each documented error response code for each endpoint is tested. This is a subset of `RESPONSE_CODE_COVERAGE`."
+        },
+        "POSITIVE_RESPONSE_CODE_COVERAGE": {
+          "name": "Positive Response Code",
+          "description": "Each documented positive (non-error) response code (1xx, 2xx, 3xx) for each endpoint is tested. This is a subset of `RESPONSE_CODE_COVERAGE`."
         },
         "RESPONSE_CODE_COVERAGE": {
           "name": "Response Code",
@@ -33,9 +41,17 @@
           "name": "Required Parameter",
           "description": "Each required parameter (in path, query) has been tested with valid values. This is a subset of `PARAMETER_COVERAGE`."
         },
+        "OPTIONAL_PARAMETER_COVERAGE": {
+          "name": "Optional Parameter",
+          "description": "Each optional (non-required) parameter (in path, query) has been tested with valid values. This is a subset of `PARAMETER_COVERAGE`."
+        },
         "PARAMETER_COVERAGE": {
           "name": "Parameter",
           "description": "Each parameter (in path, query) has been tested with valid values."
+        },
+        "CONTENT_TYPE_COVERAGE": {
+          "name": "Content Type",
+          "description": "Each documented request body content type (e.g. `application/json`, `multipart/form-data`) for each endpoint has been exercised."
         },
         "REQUIRED_ERROR_FIELDS_COVERAGE": {
           "name": "Required Error Fields",

--- a/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/ContentTypeCoverageCalculator.java
+++ b/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/ContentTypeCoverageCalculator.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2026 Timon Borter <timon.borter@gmx.ch>
+ * Licensed under the Polyform Small Business License 1.0.0
+ * See LICENSE file for full details.
+ */
+
+package io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.calculator;
+
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.CONTENT_TYPE_COVERAGE;
+import static io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.calculator.CalculatorUtils.getTelemetryForTemplate;
+import static io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.calculator.MathUtils.calculatePercentage;
+import static java.lang.String.format;
+import static java.lang.String.join;
+import static java.util.Objects.isNull;
+
+import io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria;
+import io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.dto.OpenTelemetryData;
+import io.swagger.v3.oas.models.Operation;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * Calculator for the following criteria:
+ * Each documented request body content type for each endpoint has been exercised.
+ * Operations without a request body are skipped.
+ *
+ * @see OpenApiCriteria#CONTENT_TYPE_COVERAGE
+ */
+@Slf4j
+@Component
+public class ContentTypeCoverageCalculator
+  extends AbstractOpenApiCoverageCalculator
+{
+
+  static final String CONTENT_TYPE_HEADER_KEY =
+    "http.request.header.content-type";
+
+  @Override
+  protected @NonNull OpenApiCriteria getSupportedOpenApiCriteria() {
+    return CONTENT_TYPE_COVERAGE;
+  }
+
+  @Override
+  protected @NonNull CoverageCalculationResult calculateCoverage(
+    Map<String, Operation> pathToOpenAPIOperationMap,
+    Map<String, List<OpenTelemetryData>> pathToTelemetryMap
+  ) {
+    var coveredContentTypes = new AtomicInteger(0);
+    var totalContentTypes = new AtomicInteger(0);
+
+    var uncoveredContentTypes = new HashSet<String>();
+
+    for (Map.Entry<
+      String,
+      Operation
+    > entry : pathToOpenAPIOperationMap.entrySet()) {
+      String operationKey = entry.getKey();
+      Operation operation = entry.getValue();
+
+      var specContentTypes = extractSpecContentTypes(operation);
+      if (specContentTypes.isEmpty()) {
+        logger.trace(
+          "Operation '{}' has no request body content types defined — skipping",
+          operationKey
+        );
+        continue;
+      }
+
+      totalContentTypes.addAndGet(specContentTypes.size());
+
+      var telemetryList = getTelemetryForTemplate(
+        pathToTelemetryMap,
+        operationKey
+      );
+      var observedContentTypes = extractObservedContentTypes(telemetryList);
+
+      for (String specContentType : specContentTypes) {
+        if (isContentTypeCovered(specContentType, observedContentTypes)) {
+          logger.trace(
+            "Content type '{}' covered for operation '{}'",
+            specContentType,
+            operationKey
+          );
+          coveredContentTypes.incrementAndGet();
+        } else {
+          logger.trace(
+            "Content type '{}' NOT covered for operation '{}'",
+            specContentType,
+            operationKey
+          );
+          uncoveredContentTypes.add(
+            format("%s [%s]", operationKey, specContentType)
+          );
+        }
+      }
+    }
+
+    var coverage = calculatePercentage(
+      coveredContentTypes.get(),
+      totalContentTypes.get()
+    );
+
+    return new CoverageCalculationResult(
+      coverage,
+      getAdditionalInformationOrNull(uncoveredContentTypes)
+    );
+  }
+
+  private Set<String> extractSpecContentTypes(Operation operation) {
+    if (
+      isNull(operation.getRequestBody()) ||
+      isNull(operation.getRequestBody().getContent())
+    ) {
+      return Set.of();
+    }
+
+    return operation.getRequestBody().getContent().keySet();
+  }
+
+  private Set<String> extractObservedContentTypes(
+    List<OpenTelemetryData> telemetryList
+  ) {
+    var observed = new HashSet<String>();
+
+    for (OpenTelemetryData data : telemetryList) {
+      if (isNull(data.attributes())) {
+        continue;
+      }
+
+      JsonNode headerNode = data.attributes().get(CONTENT_TYPE_HEADER_KEY);
+      if (isNull(headerNode)) {
+        continue;
+      }
+
+      // OTel may represent header values as a JSON array or a plain string
+      if (headerNode.isArray()) {
+        headerNode.forEach(element -> observed.add(element.asText()));
+      } else {
+        observed.add(headerNode.asText());
+      }
+    }
+
+    return observed;
+  }
+
+  /**
+   * Checks whether {@code specContentType} is covered by any observed value.
+   * An observed value matches when it starts with the spec content type, allowing
+   * for parameters such as {@code ; charset=utf-8}.
+   */
+  private boolean isContentTypeCovered(
+    String specContentType,
+    Set<String> observedContentTypes
+  ) {
+    for (String observed : observedContentTypes) {
+      if (observed.startsWith(specContentType)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private @Nullable String getAdditionalInformationOrNull(
+    @NonNull Set<String> uncoveredContentTypes
+  ) {
+    if (uncoveredContentTypes.isEmpty()) {
+      return null;
+    }
+
+    var sorted = uncoveredContentTypes.stream().sorted().toList();
+
+    return format(
+      "The following request body content types are uncovered: `%s`",
+      join("`, `", sorted)
+    );
+  }
+}

--- a/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/ContentTypeCoverageCalculator.java
+++ b/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/ContentTypeCoverageCalculator.java
@@ -142,9 +142,9 @@ public class ContentTypeCoverageCalculator
 
       // OTel may represent header values as a JSON array or a plain string
       if (headerNode.isArray()) {
-        headerNode.forEach(element -> observed.add(element.asText()));
+        headerNode.forEach(element -> observed.add(element.asString()));
       } else {
-        observed.add(headerNode.asText());
+        observed.add(headerNode.asString());
       }
     }
 

--- a/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/HttpStatusCodeUtils.java
+++ b/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/HttpStatusCodeUtils.java
@@ -27,4 +27,18 @@ final class HttpStatusCodeUtils {
       );
     }
   }
+
+  static boolean isPositiveHttpStatusCode(String statusCode) {
+    try {
+      int code = parseInt(statusCode);
+      return code >= 100 && code <= 399;
+    } catch (NumberFormatException _) {
+      // Handle patterns like "1XX", "2XX", "3XX"
+      return (
+        statusCode.startsWith("1") ||
+        statusCode.startsWith("2") ||
+        statusCode.startsWith("3")
+      );
+    }
+  }
 }

--- a/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/OperationSuccessCoverageCalculator.java
+++ b/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/OperationSuccessCoverageCalculator.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Timon Borter <timon.borter@gmx.ch>
+ * Licensed under the Polyform Small Business License 1.0.0
+ * See LICENSE file for full details.
+ */
+
+package io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.calculator;
+
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.OPERATION_SUCCESS_COVERAGE;
+import static io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.calculator.CalculatorUtils.getTelemetryForTemplate;
+import static io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.calculator.MathUtils.calculatePercentage;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static java.lang.Integer.parseInt;
+import static java.lang.String.format;
+import static java.lang.String.join;
+import static java.util.Objects.isNull;
+
+import io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria;
+import io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.dto.OpenTelemetryData;
+import io.swagger.v3.oas.models.Operation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+
+/**
+ * Calculator for the following criteria:
+ * Each operation has produced at least one successful (2xx) response.
+ * <p>
+ * This is distinct from {@link OpenApiCriteria#HTTP_METHOD_COVERAGE}, which only checks that
+ * an operation was called at all. This calculator additionally verifies that at least one call
+ * resulted in a success response, distinguishing "untested" operations from "called but never
+ * succeeded" ones.
+ *
+ * @see OpenApiCriteria#OPERATION_SUCCESS_COVERAGE
+ */
+@Slf4j
+@Component
+public class OperationSuccessCoverageCalculator
+  extends AbstractOpenApiCoverageCalculator
+{
+
+  @Override
+  protected @NonNull OpenApiCriteria getSupportedOpenApiCriteria() {
+    return OPERATION_SUCCESS_COVERAGE;
+  }
+
+  @Override
+  protected @NonNull CoverageCalculationResult calculateCoverage(
+    Map<String, Operation> pathToOpenAPIOperationMap,
+    Map<String, List<OpenTelemetryData>> pathToTelemetryMap
+  ) {
+    var successfulOperations = new AtomicInteger(0);
+    var unsuccessfulOperations = new ArrayList<String>();
+
+    for (String operationKey : pathToOpenAPIOperationMap.keySet()) {
+      var telemetryList = getTelemetryForTemplate(
+        pathToTelemetryMap,
+        operationKey
+      );
+
+      if (hasSuccessfulResponse(telemetryList)) {
+        logger.trace(
+          "Operation '{}' has at least one 2xx response",
+          operationKey
+        );
+        successfulOperations.incrementAndGet();
+      } else {
+        logger.trace(
+          "Operation '{}' has no 2xx response observed",
+          operationKey
+        );
+        unsuccessfulOperations.add(operationKey);
+      }
+    }
+
+    var coverage = calculatePercentage(
+      successfulOperations.get(),
+      pathToOpenAPIOperationMap.size()
+    );
+
+    return new CoverageCalculationResult(
+      coverage,
+      getAdditionalInformationOrNull(unsuccessfulOperations)
+    );
+  }
+
+  private boolean hasSuccessfulResponse(List<OpenTelemetryData> telemetryList) {
+    for (OpenTelemetryData data : telemetryList) {
+      if (isNull(data.attributes())) {
+        continue;
+      }
+
+      if (!data.attributes().has(HTTP_RESPONSE_STATUS_CODE.getKey())) {
+        continue;
+      }
+
+      String statusCode = data
+        .attributes()
+        .get(HTTP_RESPONSE_STATUS_CODE.getKey())
+        .asText();
+
+      try {
+        if (HttpStatusCode.valueOf(parseInt(statusCode)).is2xxSuccessful()) {
+          return true;
+        }
+      } catch (NumberFormatException _) {
+        logger.trace(
+          "Skipping non-numeric status code '{}' in success check",
+          statusCode
+        );
+      }
+    }
+
+    return false;
+  }
+
+  private @Nullable String getAdditionalInformationOrNull(
+    @NonNull List<String> unsuccessfulOperations
+  ) {
+    if (unsuccessfulOperations.isEmpty()) {
+      return null;
+    }
+
+    var sorted = unsuccessfulOperations.stream().sorted().toList();
+
+    return format(
+      "The following operations have no successful (2xx) response observed: `%s`",
+      join("`, `", sorted)
+    );
+  }
+}

--- a/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/OperationSuccessCoverageCalculator.java
+++ b/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/OperationSuccessCoverageCalculator.java
@@ -92,18 +92,17 @@ public class OperationSuccessCoverageCalculator
 
   private boolean hasSuccessfulResponse(List<OpenTelemetryData> telemetryList) {
     for (OpenTelemetryData data : telemetryList) {
-      if (isNull(data.attributes())) {
-        continue;
-      }
-
-      if (!data.attributes().has(HTTP_RESPONSE_STATUS_CODE.getKey())) {
+      if (
+        isNull(data.attributes()) ||
+        !data.attributes().has(HTTP_RESPONSE_STATUS_CODE.getKey())
+      ) {
         continue;
       }
 
       String statusCode = data
         .attributes()
         .get(HTTP_RESPONSE_STATUS_CODE.getKey())
-        .asText();
+        .asString();
 
       try {
         if (HttpStatusCode.valueOf(parseInt(statusCode)).is2xxSuccessful()) {

--- a/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/OptionalParameterCoverageCalculator.java
+++ b/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/OptionalParameterCoverageCalculator.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Timon Borter <timon.borter@gmx.ch>
+ * Licensed under the Polyform Small Business License 1.0.0
+ * See LICENSE file for full details.
+ */
+
+package io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.calculator;
+
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.OPTIONAL_PARAMETER_COVERAGE;
+import static java.lang.Boolean.TRUE;
+import static java.lang.String.format;
+import static java.lang.String.join;
+
+import io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import java.util.List;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Calculator for the following criteria:
+ * Each optional (non-required) parameter (in path, query) has been tested with valid values.
+ * This is a subset of {@link OpenApiCriteria#PARAMETER_COVERAGE}.
+ *
+ * @see OpenApiCriteria#OPTIONAL_PARAMETER_COVERAGE
+ */
+@Slf4j
+@Component
+public class OptionalParameterCoverageCalculator
+  extends ParameterCoverageCalculator
+{
+
+  @Override
+  protected @NonNull OpenApiCriteria getSupportedOpenApiCriteria() {
+    return OPTIONAL_PARAMETER_COVERAGE;
+  }
+
+  @Override
+  protected List<Parameter> extractParameters(Operation operation) {
+    return operation
+      .getParameters()
+      .stream()
+      .filter(param -> !TRUE.equals(param.getRequired()))
+      .toList();
+  }
+
+  @Override
+  protected @Nullable String getAdditionalInformationOrNull(
+    @NonNull Set<String> uncoveredParameters
+  ) {
+    if (uncoveredParameters.isEmpty()) {
+      return null;
+    }
+
+    var sortedParameters = uncoveredParameters.stream().sorted().toList();
+
+    return format(
+      "The following optional parameters are uncovered: `%s`",
+      join("`, `", sortedParameters)
+    );
+  }
+}

--- a/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/PositiveResponseCodeCoverageCalculator.java
+++ b/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/PositiveResponseCodeCoverageCalculator.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Timon Borter <timon.borter@gmx.ch>
+ * Licensed under the Polyform Small Business License 1.0.0
+ * See LICENSE file for full details.
+ */
+
+package io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.calculator;
+
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.POSITIVE_RESPONSE_CODE_COVERAGE;
+import static io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.calculator.HttpStatusCodeUtils.isPositiveHttpStatusCode;
+import static java.lang.String.format;
+import static java.util.regex.Pattern.compile;
+
+import io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Calculator for the following criteria:
+ * Each documented positive (non-error) response code for each endpoint is tested.
+ * This is a subset of {@link OpenApiCriteria#RESPONSE_CODE_COVERAGE}.
+ *
+ * @see OpenApiCriteria#POSITIVE_RESPONSE_CODE_COVERAGE
+ */
+@Slf4j
+@Component
+public class PositiveResponseCodeCoverageCalculator
+  extends ResponseCodeCoverageCalculator
+{
+
+  @Override
+  protected @NonNull OpenApiCriteria getSupportedOpenApiCriteria() {
+    return POSITIVE_RESPONSE_CODE_COVERAGE;
+  }
+
+  @Override
+  protected Set<ResponseCode> extractResponseCodes(Operation operation) {
+    Set<ResponseCode> positiveResponseCodes = new HashSet<>();
+
+    if (operation.getResponses() == null) {
+      return positiveResponseCodes;
+    }
+
+    for (Map.Entry<String, ApiResponse> responseEntry : operation
+      .getResponses()
+      .entrySet()) {
+      String statusCode = responseEntry.getKey();
+
+      if (!isPositiveHttpStatusCode(statusCode)) {
+        continue;
+      }
+
+      if (isResponseCodePattern(statusCode)) {
+        positiveResponseCodes.add(
+          new ResponseCode(
+            statusCode,
+            compile(format("^%s\\d\\d$", statusCode.charAt(0)))
+          )
+        );
+      } else {
+        positiveResponseCodes.add(
+          new ResponseCode(statusCode, compile(format("^%s$", statusCode)))
+        );
+      }
+    }
+
+    return positiveResponseCodes;
+  }
+
+  @Override
+  protected boolean includeObservedResponseCodeInCalculation(
+    @Nullable String statusCode
+  ) {
+    return statusCode != null && isPositiveHttpStatusCode(statusCode);
+  }
+
+  @Override
+  protected @Nullable String getAdditionalInformationOrNull(
+    @NonNull Set<String> uncoveredPositiveCodes
+  ) {
+    return super.getAdditionalInformationOrNull(
+      "The following positive response codes in paths are uncovered: `%s`",
+      uncoveredPositiveCodes
+    );
+  }
+}

--- a/microservices/openapi-coverage-stream/src/test/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/ContentTypeCoverageCalculatorTest.java
+++ b/microservices/openapi-coverage-stream/src/test/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/ContentTypeCoverageCalculatorTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2026 Timon Borter <timon.borter@gmx.ch>
+ * Licensed under the Polyform Small Business License 1.0.0
+ * See LICENSE file for full details.
+ */
+
+package io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.calculator;
+
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.CONTENT_TYPE_COVERAGE;
+import static io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.calculator.ContentTypeCoverageCalculator.CONTENT_TYPE_HEADER_KEY;
+import static java.math.RoundingMode.HALF_UP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
+
+import io.github.bbortt.snow.white.commons.event.dto.OpenApiTestResult;
+import io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria;
+import io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.dto.OpenTelemetryData;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.json.JsonMapper;
+
+@ExtendWith({ MockitoExtension.class })
+class ContentTypeCoverageCalculatorTest {
+
+  private ContentTypeCoverageCalculator fixture;
+
+  @BeforeEach
+  void beforeEachSetup() {
+    fixture = new ContentTypeCoverageCalculator();
+  }
+
+  @Nested
+  class AcceptsTest {
+
+    @Test
+    void shouldReturnTrue_whenContentTypeCoverage() {
+      boolean result = fixture.accepts(CONTENT_TYPE_COVERAGE);
+
+      assertThat(result).isTrue();
+    }
+
+    @EnumSource
+    @ParameterizedTest
+    void shouldReturnFalse_whenNotContentTypeCoverage(
+      OpenApiCriteria openApiCriteria
+    ) {
+      if (CONTENT_TYPE_COVERAGE.equals(openApiCriteria)) {
+        return;
+      }
+
+      boolean result = fixture.accepts(openApiCriteria);
+
+      assertThat(result).isFalse();
+    }
+  }
+
+  @Nested
+  class CalculatesTest {
+
+    @Test
+    void shouldReturn100Percent_whenAllContentTypesCovered() {
+      var pathToOpenAPIOperationMap = Map.of(
+        "POST_/api/v1/users",
+        operationWithContentTypes("application/json", "multipart/form-data")
+      );
+
+      var pathToTelemetryMap = Map.of(
+        "POST_/api/v1/users",
+        List.of(
+          telemetryWithContentType("application/json"),
+          telemetryWithContentType("multipart/form-data")
+        )
+      );
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r -> assertThat(r.openApiCriteria()).isEqualTo(CONTENT_TYPE_COVERAGE),
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(1.0)),
+        r ->
+          assertThat(r.duration())
+            .isNotNull()
+            .extracting(Duration::getNano)
+            .asInstanceOf(INTEGER)
+            .isPositive(),
+        r -> assertThat(r.additionalInformation()).isNull()
+      );
+    }
+
+    @Test
+    void shouldReturn50Percent_whenSomeContentTypesCovered() {
+      var pathToOpenAPIOperationMap = Map.of(
+        "POST_/api/v1/documents",
+        operationWithContentTypes("application/json", "multipart/form-data")
+      );
+
+      var pathToTelemetryMap = Map.of(
+        "POST_/api/v1/documents",
+        List.of(telemetryWithContentType("application/json"))
+      );
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r -> assertThat(r.openApiCriteria()).isEqualTo(CONTENT_TYPE_COVERAGE),
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(0.5)),
+        r ->
+          assertThat(r.additionalInformation()).isEqualTo(
+            "The following request body content types are uncovered: `POST_/api/v1/documents [multipart/form-data]`"
+          )
+      );
+    }
+
+    @Test
+    void shouldReturn0Percent_whenNoContentTypesCovered() {
+      var pathToOpenAPIOperationMap = Map.of(
+        "POST_/api/v1/users",
+        operationWithContentTypes("application/json")
+      );
+
+      var pathToTelemetryMap = new HashMap<String, List<OpenTelemetryData>>();
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r -> assertThat(r.openApiCriteria()).isEqualTo(CONTENT_TYPE_COVERAGE),
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(0.0)),
+        r ->
+          assertThat(r.additionalInformation()).isEqualTo(
+            "The following request body content types are uncovered: `POST_/api/v1/users [application/json]`"
+          )
+      );
+    }
+
+    @Test
+    void shouldSkipOperationsWithNoRequestBody() {
+      var operationWithoutBody = new Operation();
+
+      var pathToOpenAPIOperationMap = Map.of(
+        "GET_/api/v1/users",
+        operationWithoutBody
+      );
+
+      var pathToTelemetryMap = new HashMap<String, List<OpenTelemetryData>>();
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(1.0)), // 0/0 = 100%
+        r -> assertThat(r.additionalInformation()).isNull()
+      );
+    }
+
+    @Test
+    void shouldMatchContentTypeWithCharsetSuffix() {
+      var pathToOpenAPIOperationMap = Map.of(
+        "POST_/api/v1/users",
+        operationWithContentTypes("application/json")
+      );
+
+      // Observed value includes charset parameter — should still match
+      var pathToTelemetryMap = Map.of(
+        "POST_/api/v1/users",
+        List.of(telemetryWithContentType("application/json; charset=utf-8"))
+      );
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(1.0)),
+        r -> assertThat(r.additionalInformation()).isNull()
+      );
+    }
+
+    @Test
+    void shouldHandleContentTypeAsJsonArray() {
+      var pathToOpenAPIOperationMap = Map.of(
+        "POST_/api/v1/users",
+        operationWithContentTypes("application/json")
+      );
+
+      var attributes = JsonMapper.shared().createObjectNode();
+      var arrayNode = attributes.putArray(CONTENT_TYPE_HEADER_KEY);
+      arrayNode.add("application/json");
+
+      var pathToTelemetryMap = Map.of(
+        "POST_/api/v1/users",
+        List.of(new OpenTelemetryData("span-1", "trace-1", attributes))
+      );
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(1.0)),
+        r -> assertThat(r.additionalInformation()).isNull()
+      );
+    }
+
+    @Test
+    void shouldHandleMultipleOperations() {
+      var pathToOpenAPIOperationMap = Map.of(
+        "POST_/api/v1/users",
+        operationWithContentTypes("application/json"),
+        "PUT_/api/v1/users/{id}",
+        operationWithContentTypes("application/json")
+      );
+
+      var pathToTelemetryMap = Map.of(
+        "POST_/api/v1/users",
+        List.of(telemetryWithContentType("application/json")),
+        "PUT_/api/v1/users/42",
+        List.of(telemetryWithContentType("application/json"))
+      );
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(1.0)),
+        r -> assertThat(r.additionalInformation()).isNull()
+      );
+    }
+
+    private Operation operationWithContentTypes(String... contentTypes) {
+      var content = new Content();
+      for (String contentType : contentTypes) {
+        content.addMediaType(contentType, new MediaType());
+      }
+
+      var requestBody = new RequestBody();
+      requestBody.setContent(content);
+
+      var operation = new Operation();
+      operation.setRequestBody(requestBody);
+      return operation;
+    }
+
+    private OpenTelemetryData telemetryWithContentType(String contentType) {
+      var attributes = JsonMapper.shared().createObjectNode();
+      attributes.put(CONTENT_TYPE_HEADER_KEY, contentType);
+      return new OpenTelemetryData("span-1", "trace-1", attributes);
+    }
+
+    private static @NonNull BigDecimal getBigDecimal(double value) {
+      return BigDecimal.valueOf(value).setScale(2, HALF_UP);
+    }
+  }
+}

--- a/microservices/openapi-coverage-stream/src/test/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/HttpStatusCodeUtilsTest.java
+++ b/microservices/openapi-coverage-stream/src/test/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/HttpStatusCodeUtilsTest.java
@@ -61,4 +61,38 @@ class HttpStatusCodeUtilsTest {
       assertThat(HttpStatusCodeUtils.isErrorHttpStatusCode(value)).isFalse();
     }
   }
+
+  @Nested
+  class IsPositiveHttpStatusCodeTest {
+
+    @ParameterizedTest(name = "{0} → true")
+    @ValueSource(
+      strings = { "100", "101", "200", "201", "204", "301", "302", "304" }
+    )
+    void returnsTrueForPositiveCodes(String code) {
+      assertThat(HttpStatusCodeUtils.isPositiveHttpStatusCode(code)).isTrue();
+    }
+
+    @ParameterizedTest(name = "{0} → false")
+    @ValueSource(strings = { "400", "401", "403", "404", "422", "500", "503" })
+    void returnsFalseForErrorCodes(String code) {
+      assertThat(HttpStatusCodeUtils.isPositiveHttpStatusCode(code)).isFalse();
+    }
+
+    @ParameterizedTest(name = "{0} → true")
+    @ValueSource(strings = { "1XX", "2XX", "3XX", "1xx", "2xx", "3xx" })
+    void returnsTrueForPositiveWildcards(String pattern) {
+      assertThat(
+        HttpStatusCodeUtils.isPositiveHttpStatusCode(pattern)
+      ).isTrue();
+    }
+
+    @ParameterizedTest(name = "{0} → false")
+    @ValueSource(strings = { "4XX", "4xx", "5XX", "5xx", "default", "DEFAULT" })
+    void returnsFalseForErrorWildcardsAndDefault(String pattern) {
+      assertThat(
+        HttpStatusCodeUtils.isPositiveHttpStatusCode(pattern)
+      ).isFalse();
+    }
+  }
 }

--- a/microservices/openapi-coverage-stream/src/test/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/OperationSuccessCoverageCalculatorTest.java
+++ b/microservices/openapi-coverage-stream/src/test/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/OperationSuccessCoverageCalculatorTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2026 Timon Borter <timon.borter@gmx.ch>
+ * Licensed under the Polyform Small Business License 1.0.0
+ * See LICENSE file for full details.
+ */
+
+package io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.calculator;
+
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.OPERATION_SUCCESS_COVERAGE;
+import static java.math.RoundingMode.HALF_UP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
+
+import io.github.bbortt.snow.white.commons.event.dto.OpenApiTestResult;
+import io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria;
+import io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.dto.OpenTelemetryData;
+import io.swagger.v3.oas.models.Operation;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.json.JsonMapper;
+
+@ExtendWith({ MockitoExtension.class })
+class OperationSuccessCoverageCalculatorTest {
+
+  private OperationSuccessCoverageCalculator fixture;
+
+  @BeforeEach
+  void beforeEachSetup() {
+    fixture = new OperationSuccessCoverageCalculator();
+  }
+
+  @Nested
+  class AcceptsTest {
+
+    @Test
+    void shouldReturnTrue_whenOperationSuccessCoverage() {
+      boolean result = fixture.accepts(OPERATION_SUCCESS_COVERAGE);
+
+      assertThat(result).isTrue();
+    }
+
+    @EnumSource
+    @ParameterizedTest
+    void shouldReturnFalse_whenNotOperationSuccessCoverage(
+      OpenApiCriteria openApiCriteria
+    ) {
+      if (OPERATION_SUCCESS_COVERAGE.equals(openApiCriteria)) {
+        return;
+      }
+
+      boolean result = fixture.accepts(openApiCriteria);
+
+      assertThat(result).isFalse();
+    }
+  }
+
+  @Nested
+  class CalculatesTest {
+
+    @Test
+    void shouldReturn100Percent_whenAllOperationsHaveSuccessfulResponse() {
+      var pathToOpenAPIOperationMap = Map.of(
+        "GET_/api/v1/users",
+        new Operation(),
+        "POST_/api/v1/users",
+        new Operation()
+      );
+
+      var pathToTelemetryMap = Map.of(
+        "GET_/api/v1/users",
+        List.of(telemetryWithStatusCode("200")),
+        "POST_/api/v1/users",
+        List.of(telemetryWithStatusCode("201"))
+      );
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r ->
+          assertThat(r.openApiCriteria()).isEqualTo(OPERATION_SUCCESS_COVERAGE),
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(1.0)),
+        r ->
+          assertThat(r.duration())
+            .isNotNull()
+            .extracting(Duration::getNano)
+            .asInstanceOf(INTEGER)
+            .isPositive(),
+        r -> assertThat(r.additionalInformation()).isNull()
+      );
+    }
+
+    @Test
+    void shouldReturn50Percent_whenOnlySomeOperationsHaveSuccessfulResponse() {
+      var pathToOpenAPIOperationMap = Map.of(
+        "GET_/api/v1/users",
+        new Operation(),
+        "DELETE_/api/v1/users/{id}",
+        new Operation()
+      );
+
+      var pathToTelemetryMap = Map.of(
+        "GET_/api/v1/users",
+        List.of(telemetryWithStatusCode("200")),
+        "DELETE_/api/v1/users/{id}",
+        List.of(telemetryWithStatusCode("404")) // called but never succeeded
+      );
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r ->
+          assertThat(r.openApiCriteria()).isEqualTo(OPERATION_SUCCESS_COVERAGE),
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(0.5)),
+        r ->
+          assertThat(r.additionalInformation()).isEqualTo(
+            "The following operations have no successful (2xx) response observed: `DELETE_/api/v1/users/{id}`"
+          )
+      );
+    }
+
+    @Test
+    void shouldReturn0Percent_whenNoOperationsHaveSuccessfulResponse() {
+      var pathToOpenAPIOperationMap = Map.of(
+        "GET_/api/v1/users",
+        new Operation(),
+        "POST_/api/v1/users",
+        new Operation()
+      );
+
+      var pathToTelemetryMap = new HashMap<String, List<OpenTelemetryData>>();
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r ->
+          assertThat(r.openApiCriteria()).isEqualTo(OPERATION_SUCCESS_COVERAGE),
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(0.0)),
+        r -> assertThat(r.additionalInformation()).isNotNull()
+      );
+    }
+
+    @Test
+    void shouldCountOperationAsSuccessful_whenMixedResponsesInclude2xx() {
+      var pathToOpenAPIOperationMap = Map.of(
+        "POST_/api/v1/orders",
+        new Operation()
+      );
+
+      // Same operation: some calls fail, one succeeds
+      var pathToTelemetryMap = Map.of(
+        "POST_/api/v1/orders",
+        List.of(
+          telemetryWithStatusCode("400"),
+          telemetryWithStatusCode("500"),
+          telemetryWithStatusCode("201")
+        )
+      );
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(1.0)),
+        r -> assertThat(r.additionalInformation()).isNull()
+      );
+    }
+
+    @Test
+    void shouldNotCountErrorOnlyResponses_asSuccessful() {
+      var pathToOpenAPIOperationMap = Map.of(
+        "DELETE_/api/v1/users/{id}",
+        new Operation()
+      );
+
+      var pathToTelemetryMap = Map.of(
+        "DELETE_/api/v1/users/{id}",
+        List.of(
+          telemetryWithStatusCode("400"),
+          telemetryWithStatusCode("403"),
+          telemetryWithStatusCode("500")
+        )
+      );
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(0.0)),
+        r ->
+          assertThat(r.additionalInformation()).isEqualTo(
+            "The following operations have no successful (2xx) response observed: `DELETE_/api/v1/users/{id}`"
+          )
+      );
+    }
+
+    @Test
+    void shouldMatchTelemetryViaPathTemplate() {
+      var pathToOpenAPIOperationMap = Map.of(
+        "GET_/api/v1/users/{id}",
+        new Operation()
+      );
+
+      // Telemetry uses the concrete resolved path, not the template
+      var pathToTelemetryMap = Map.of(
+        "GET_/api/v1/users/42",
+        List.of(telemetryWithStatusCode("200"))
+      );
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(1.0)),
+        r -> assertThat(r.additionalInformation()).isNull()
+      );
+    }
+
+    @Test
+    void shouldHandleTelemetryWithoutStatusCode() {
+      var pathToOpenAPIOperationMap = Map.of(
+        "GET_/api/v1/users",
+        new Operation()
+      );
+
+      var attributes = JsonMapper.shared().createObjectNode();
+      attributes.put("some.other.attribute", "value");
+
+      var pathToTelemetryMap = Map.of(
+        "GET_/api/v1/users",
+        List.of(new OpenTelemetryData("span-1", "trace-1", attributes))
+      );
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(0.0)),
+        r -> assertThat(r.additionalInformation()).isNotNull()
+      );
+    }
+
+    private OpenTelemetryData telemetryWithStatusCode(String statusCode) {
+      var attributes = JsonMapper.shared().createObjectNode();
+      attributes.put("http.response.status_code", statusCode);
+      return new OpenTelemetryData("span-1", "trace-1", attributes);
+    }
+
+    private static @NonNull BigDecimal getBigDecimal(double value) {
+      return BigDecimal.valueOf(value).setScale(2, HALF_UP);
+    }
+  }
+}

--- a/microservices/openapi-coverage-stream/src/test/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/OptionalParameterCoverageCalculatorTest.java
+++ b/microservices/openapi-coverage-stream/src/test/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/OptionalParameterCoverageCalculatorTest.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2026 Timon Borter <timon.borter@gmx.ch>
+ * Licensed under the Polyform Small Business License 1.0.0
+ * See LICENSE file for full details.
+ */
+
+package io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.calculator;
+
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.OPTIONAL_PARAMETER_COVERAGE;
+import static java.math.RoundingMode.HALF_UP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
+
+import io.github.bbortt.snow.white.commons.event.dto.OpenApiTestResult;
+import io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria;
+import io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.dto.OpenTelemetryData;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.json.JsonMapper;
+
+@ExtendWith({ MockitoExtension.class })
+class OptionalParameterCoverageCalculatorTest {
+
+  private OptionalParameterCoverageCalculator fixture;
+
+  @BeforeEach
+  void beforeEachSetup() {
+    fixture = new OptionalParameterCoverageCalculator();
+  }
+
+  @Nested
+  class AcceptsTest {
+
+    @Test
+    void shouldReturnTrue_whenOptionalParameterCoverage() {
+      boolean result = fixture.accepts(OPTIONAL_PARAMETER_COVERAGE);
+
+      assertThat(result).isTrue();
+    }
+
+    @EnumSource
+    @ParameterizedTest
+    void shouldReturnFalse_whenNotOptionalParameterCoverage(
+      OpenApiCriteria openApiCriteria
+    ) {
+      if (OPTIONAL_PARAMETER_COVERAGE.equals(openApiCriteria)) {
+        return;
+      }
+
+      boolean result = fixture.accepts(openApiCriteria);
+
+      assertThat(result).isFalse();
+    }
+  }
+
+  @Nested
+  class CalculatesTest {
+
+    @Test
+    void shouldReturn100Percent_whenAllOptionalParametersCovered() {
+      var pathToOpenAPIOperationMap = createOperationsWithParameters(
+        Map.of(
+          "GET_/api/v1/users",
+          List.of(
+            createParameter("userId", "query", true),
+            createParameter("page", "query", false),
+            createParameter("size", "query", false)
+          )
+        )
+      );
+
+      var pathToTelemetryMap = createTelemetryWithQueryParams(
+        Map.of("GET_/api/v1/users", "page=1&size=10")
+      );
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r ->
+          assertThat(r.openApiCriteria()).isEqualTo(
+            OPTIONAL_PARAMETER_COVERAGE
+          ),
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(1.0)),
+        r ->
+          assertThat(r.duration())
+            .isNotNull()
+            .extracting(Duration::getNano)
+            .asInstanceOf(INTEGER)
+            .isPositive(),
+        r -> assertThat(r.additionalInformation()).isNull()
+      );
+    }
+
+    @Test
+    void shouldIgnoreRequiredParameters() {
+      var pathToOpenAPIOperationMap = createOperationsWithParameters(
+        Map.of(
+          "GET_/api/v1/users",
+          List.of(
+            createParameter("userId", "query", true),
+            createParameter("organizationId", "query", true)
+          )
+        )
+      );
+
+      var pathToTelemetryMap = new HashMap<String, List<OpenTelemetryData>>();
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r ->
+          assertThat(r.openApiCriteria()).isEqualTo(
+            OPTIONAL_PARAMETER_COVERAGE
+          ),
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(1.0)),
+        r -> assertThat(r.additionalInformation()).isNull()
+      );
+    }
+
+    @Test
+    void shouldReturn0Percent_whenOptionalParametersNotCovered() {
+      var pathToOpenAPIOperationMap = createOperationsWithParameters(
+        Map.of(
+          "GET_/api/v1/users",
+          List.of(
+            createParameter("page", "query", false),
+            createParameter("size", "query", false)
+          )
+        )
+      );
+
+      var pathToTelemetryMap = new HashMap<String, List<OpenTelemetryData>>();
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r ->
+          assertThat(r.openApiCriteria()).isEqualTo(
+            OPTIONAL_PARAMETER_COVERAGE
+          ),
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(0.0)),
+        r ->
+          assertThat(r.additionalInformation()).isEqualTo(
+            "The following optional parameters are uncovered: `GET_/api/v1/users [query: page]`, `GET_/api/v1/users [query: size]`"
+          )
+      );
+    }
+
+    @Test
+    void shouldReturn50Percent_whenSomeOptionalParametersCovered() {
+      var pathToOpenAPIOperationMap = createOperationsWithParameters(
+        Map.of(
+          "GET_/api/v1/users",
+          List.of(
+            createParameter("userId", "query", true),
+            createParameter("page", "query", false),
+            createParameter("size", "query", false)
+          )
+        )
+      );
+
+      var pathToTelemetryMap = createTelemetryWithQueryParams(
+        Map.of("GET_/api/v1/users", "page=1")
+      );
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r ->
+          assertThat(r.openApiCriteria()).isEqualTo(
+            OPTIONAL_PARAMETER_COVERAGE
+          ),
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(0.5)),
+        r ->
+          assertThat(r.additionalInformation()).isEqualTo(
+            "The following optional parameters are uncovered: `GET_/api/v1/users [query: size]`"
+          )
+      );
+    }
+
+    @Test
+    void shouldHandleMultipleOperations() {
+      var pathToOpenAPIOperationMap = createOperationsWithParameters(
+        Map.of(
+          "GET_/api/v1/users",
+          List.of(createParameter("page", "query", false)),
+          "GET_/api/v1/orders",
+          List.of(createParameter("filter", "query", false))
+        )
+      );
+
+      var pathToTelemetryMap = createTelemetryWithQueryParams(
+        Map.of(
+          "GET_/api/v1/users",
+          "page=2",
+          "GET_/api/v1/orders",
+          "filter=active"
+        )
+      );
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(1.0)),
+        r -> assertThat(r.additionalInformation()).isNull()
+      );
+    }
+
+    private Map<String, Operation> createOperationsWithParameters(
+      Map<String, List<Parameter>> pathToParameters
+    ) {
+      Map<String, Operation> result = new HashMap<>();
+
+      for (Map.Entry<
+        String,
+        List<Parameter>
+      > entry : pathToParameters.entrySet()) {
+        Operation operation = new Operation();
+        if (!entry.getValue().isEmpty()) {
+          operation.setParameters(new ArrayList<>(entry.getValue()));
+        }
+        result.put(entry.getKey(), operation);
+      }
+
+      return result;
+    }
+
+    private Parameter createParameter(
+      String name,
+      String in,
+      boolean required
+    ) {
+      Parameter param = new Parameter();
+      param.setName(name);
+      param.setIn(in);
+      param.setRequired(required);
+      return param;
+    }
+
+    private Map<String, List<OpenTelemetryData>> createTelemetryWithQueryParams(
+      Map<String, String> pathToQueryString
+    ) {
+      Map<String, List<OpenTelemetryData>> result = new HashMap<>();
+
+      for (Map.Entry<String, String> entry : pathToQueryString.entrySet()) {
+        var attributes = JsonMapper.shared().createObjectNode();
+        if (!entry.getValue().isEmpty()) {
+          attributes.put("url.query", entry.getValue());
+        }
+
+        result.put(
+          entry.getKey(),
+          List.of(new OpenTelemetryData("span-123", "trace-456", attributes))
+        );
+      }
+
+      return result;
+    }
+
+    private static @NonNull BigDecimal getBigDecimal(double value) {
+      return BigDecimal.valueOf(value).setScale(2, HALF_UP);
+    }
+  }
+}

--- a/microservices/openapi-coverage-stream/src/test/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/PositiveResponseCodeCoverageCalculatorTest.java
+++ b/microservices/openapi-coverage-stream/src/test/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/calculator/PositiveResponseCodeCoverageCalculatorTest.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright (c) 2026 Timon Borter <timon.borter@gmx.ch>
+ * Licensed under the Polyform Small Business License 1.0.0
+ * See LICENSE file for full details.
+ */
+
+package io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.calculator;
+
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.POSITIVE_RESPONSE_CODE_COVERAGE;
+import static java.math.RoundingMode.HALF_UP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
+
+import io.github.bbortt.snow.white.commons.event.dto.OpenApiTestResult;
+import io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria;
+import io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.dto.OpenTelemetryData;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.json.JsonMapper;
+
+@ExtendWith({ MockitoExtension.class })
+class PositiveResponseCodeCoverageCalculatorTest {
+
+  private PositiveResponseCodeCoverageCalculator fixture;
+
+  @BeforeEach
+  void beforeEachSetup() {
+    fixture = new PositiveResponseCodeCoverageCalculator();
+  }
+
+  @Nested
+  class AcceptsTest {
+
+    @Test
+    void shouldReturnTrue_whenPositiveResponseCodeCoverage() {
+      boolean result = fixture.accepts(POSITIVE_RESPONSE_CODE_COVERAGE);
+
+      assertThat(result).isTrue();
+    }
+
+    @EnumSource
+    @ParameterizedTest
+    void shouldReturnFalse_whenNotPositiveResponseCodeCoverage(
+      OpenApiCriteria openApiCriteria
+    ) {
+      if (POSITIVE_RESPONSE_CODE_COVERAGE.equals(openApiCriteria)) {
+        return;
+      }
+
+      boolean result = fixture.accepts(openApiCriteria);
+
+      assertThat(result).isFalse();
+    }
+  }
+
+  @Nested
+  class CalculatesTest {
+
+    @Test
+    void shouldReturn100Percent_whenAllPositiveCodesCovered() {
+      var pathToOpenAPIOperationMap = createOperationsWithPositiveCodes(
+        Map.of(
+          "GET_/api/v1/users",
+          List.of("200", "201"),
+          "POST_/api/v1/users",
+          List.of("201", "302")
+        )
+      );
+
+      var pathToTelemetryMap = createTelemetryWithStatusCodes(
+        Map.of(
+          "GET_/api/v1/users",
+          List.of("200", "201"),
+          "POST_/api/v1/users",
+          List.of("201", "302")
+        )
+      );
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r ->
+          assertThat(r.openApiCriteria()).isEqualTo(
+            POSITIVE_RESPONSE_CODE_COVERAGE
+          ),
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(1.0)),
+        r ->
+          assertThat(r.duration())
+            .isNotNull()
+            .extracting(Duration::getNano)
+            .asInstanceOf(INTEGER)
+            .isPositive(),
+        r -> assertThat(r.additionalInformation()).isNull()
+      );
+    }
+
+    @Test
+    void shouldReturn50Percent_whenSomePositiveCodesCovered() {
+      var pathToOpenAPIOperationMap = createOperationsWithPositiveCodes(
+        Map.of("GET_/api/v1/users", List.of("200", "201"))
+      );
+
+      var pathToTelemetryMap = createTelemetryWithStatusCodes(
+        Map.of("GET_/api/v1/users", List.of("200")) // Missing 201
+      );
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r ->
+          assertThat(r.openApiCriteria()).isEqualTo(
+            POSITIVE_RESPONSE_CODE_COVERAGE
+          ),
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(0.5)),
+        r ->
+          assertThat(r.additionalInformation()).isEqualTo(
+            "The following positive response codes in paths are uncovered: `GET_/api/v1/users [201]`"
+          )
+      );
+    }
+
+    @Test
+    void shouldReturn0Percent_whenNoPositiveCodesCovered() {
+      var pathToOpenAPIOperationMap = createOperationsWithPositiveCodes(
+        Map.of("GET_/api/v1/users", List.of("200", "204"))
+      );
+
+      var pathToTelemetryMap = new HashMap<String, List<OpenTelemetryData>>();
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r ->
+          assertThat(r.openApiCriteria()).isEqualTo(
+            POSITIVE_RESPONSE_CODE_COVERAGE
+          ),
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(0.0)),
+        r ->
+          assertThat(r.additionalInformation()).isEqualTo(
+            "The following positive response codes in paths are uncovered: `GET_/api/v1/users [200]`, `GET_/api/v1/users [204]`"
+          )
+      );
+    }
+
+    @Test
+    void shouldIgnoreErrorStatusCodes_whenPresentInTelemetry() {
+      var pathToOpenAPIOperationMap = createOperationsWithPositiveCodes(
+        Map.of("GET_/api/v1/users", List.of("200"))
+      );
+
+      var pathToTelemetryMap = createTelemetryWithStatusCodes(
+        Map.of("GET_/api/v1/users", List.of("200", "400", "500"))
+      );
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(1.0)),
+        r -> assertThat(r.additionalInformation()).isNull()
+      );
+    }
+
+    @Test
+    void shouldHandlePatternPositiveCodes() {
+      var pathToOpenAPIOperationMap = createOperationsWithPositiveCodes(
+        Map.of("GET_/api/v1/users", List.of("2XX", "3XX"))
+      );
+
+      var pathToTelemetryMap = createTelemetryWithStatusCodes(
+        Map.of("GET_/api/v1/users", List.of("200", "301"))
+      );
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(1.0)),
+        r -> assertThat(r.additionalInformation()).isNull()
+      );
+    }
+
+    @Test
+    void shouldHandleOperationWithOnlyErrorResponses() {
+      var pathToOpenAPIOperationMap = createOperationsWithErrorCodesOnly(
+        Map.of("DELETE_/api/v1/users/{id}", List.of("400", "404", "500"))
+      );
+
+      var pathToTelemetryMap = createTelemetryWithStatusCodes(
+        Map.of("DELETE_/api/v1/users/{id}", List.of("400"))
+      );
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(1.0)), // No positive codes to cover
+        r -> assertThat(r.additionalInformation()).isNull()
+      );
+    }
+
+    @Test
+    void shouldHandleNullResponses() {
+      var operationWithNullResponses = new Operation();
+      operationWithNullResponses.setResponses(null);
+
+      var pathToOpenAPIOperationMap = Map.of(
+        "GET_/api/v1/users",
+        operationWithNullResponses
+      );
+
+      var pathToTelemetryMap = createTelemetryWithStatusCodes(
+        Map.of("GET_/api/v1/users", List.of("200"))
+      );
+
+      OpenApiTestResult result = fixture.calculate(
+        pathToOpenAPIOperationMap,
+        pathToTelemetryMap
+      );
+
+      assertThat(result).satisfies(
+        r -> assertThat(r.coverage()).isEqualTo(getBigDecimal(1.0)),
+        r -> assertThat(r.additionalInformation()).isNull()
+      );
+    }
+
+    private Map<String, Operation> createOperationsWithPositiveCodes(
+      Map<String, List<String>> pathToPositiveCodes
+    ) {
+      Map<String, Operation> result = new HashMap<>();
+
+      for (Map.Entry<
+        String,
+        List<String>
+      > entry : pathToPositiveCodes.entrySet()) {
+        Operation operation = new Operation();
+        ApiResponses responses = new ApiResponses();
+
+        for (String positiveCode : entry.getValue()) {
+          responses.addApiResponse(
+            positiveCode,
+            new ApiResponse().description("Success")
+          );
+        }
+
+        // Always add an error response to verify it is excluded
+        responses.addApiResponse(
+          "500",
+          new ApiResponse().description("Internal Server Error")
+        );
+
+        operation.setResponses(responses);
+        result.put(entry.getKey(), operation);
+      }
+
+      return result;
+    }
+
+    private Map<String, Operation> createOperationsWithErrorCodesOnly(
+      Map<String, List<String>> pathToErrorCodes
+    ) {
+      Map<String, Operation> result = new HashMap<>();
+
+      for (Map.Entry<
+        String,
+        List<String>
+      > entry : pathToErrorCodes.entrySet()) {
+        Operation operation = new Operation();
+        ApiResponses responses = new ApiResponses();
+
+        for (String errorCode : entry.getValue()) {
+          responses.addApiResponse(
+            errorCode,
+            new ApiResponse().description("Error")
+          );
+        }
+
+        operation.setResponses(responses);
+        result.put(entry.getKey(), operation);
+      }
+
+      return result;
+    }
+
+    private Map<String, List<OpenTelemetryData>> createTelemetryWithStatusCodes(
+      Map<String, List<String>> pathToStatusCodes
+    ) {
+      Map<String, List<OpenTelemetryData>> result = new HashMap<>();
+
+      for (Map.Entry<
+        String,
+        List<String>
+      > entry : pathToStatusCodes.entrySet()) {
+        List<OpenTelemetryData> telemetryList = entry
+          .getValue()
+          .stream()
+          .map(statusCode ->
+            createTelemetryDataWithAttribute(
+              "http.response.status_code",
+              statusCode
+            )
+          )
+          .toList();
+
+        result.put(entry.getKey(), telemetryList);
+      }
+
+      return result;
+    }
+
+    private OpenTelemetryData createTelemetryDataWithAttribute(
+      String attributeName,
+      String value
+    ) {
+      var attributes = JsonMapper.shared().createObjectNode();
+      attributes.put(attributeName, value);
+
+      return new OpenTelemetryData("span-123", "trace-456", attributes);
+    }
+
+    private static @NonNull BigDecimal getBigDecimal(double value) {
+      return BigDecimal.valueOf(value).setScale(2, HALF_UP);
+    }
+  }
+}

--- a/microservices/quality-gate-api/src/main/java/io/github/bbortt/snow/white/microservices/quality/gate/api/service/DefaultOpenApiQualityGates.java
+++ b/microservices/quality-gate-api/src/main/java/io/github/bbortt/snow/white/microservices/quality/gate/api/service/DefaultOpenApiQualityGates.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026 Timon Borter <timon.borter@gmx.ch>
+ * Licensed under the Polyform Small Business License 1.0.0
+ * See LICENSE file for full details.
+ */
+
+package io.github.bbortt.snow.white.microservices.quality.gate.api.service;
+
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.CONTENT_TYPE_COVERAGE;
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.ERROR_RESPONSE_CODE_COVERAGE;
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.HTTP_METHOD_COVERAGE;
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.NO_UNDOCUMENTED_ERROR_RESPONSE_CODES;
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.NO_UNDOCUMENTED_POSITIVE_RESPONSE_CODES;
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.NO_UNDOCUMENTED_RESPONSE_CODES;
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.OPERATION_SUCCESS_COVERAGE;
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.OPTIONAL_PARAMETER_COVERAGE;
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.PARAMETER_COVERAGE;
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.PATH_COVERAGE;
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.POSITIVE_RESPONSE_CODE_COVERAGE;
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.REQUIRED_ERROR_FIELDS_COVERAGE;
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.REQUIRED_PARAMETER_COVERAGE;
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.RESPONSE_CODE_COVERAGE;
+import static java.lang.Boolean.TRUE;
+
+import io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria;
+import io.github.bbortt.snow.white.microservices.quality.gate.api.domain.model.QualityGateConfiguration;
+import io.github.bbortt.snow.white.microservices.quality.gate.api.domain.model.QualityGateOpenApiCoverageMapping;
+import io.github.bbortt.snow.white.microservices.quality.gate.api.domain.repository.OpenApiCoverageConfigurationRepository;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.stereotype.Component;
+
+@Component
+@NullMarked
+@RequiredArgsConstructor
+public final class DefaultOpenApiQualityGates {
+
+  private final OpenApiCoverageConfigurationRepository openApiCoverageConfigurationRepository;
+
+  public Set<
+    QualityGateConfiguration
+  > getDefaultOpenApiCoverageConfigurations() {
+    // LinkedHashSet preserves insertion order for deterministic iteration
+    var gates = new LinkedHashSet<QualityGateConfiguration>();
+    gates.add(getBasicCoverage());
+    gates.add(getFullFeature());
+    gates.add(getMinimal());
+    gates.add(getDryRun());
+    return gates;
+  }
+
+  private QualityGateConfiguration getBasicCoverage() {
+    var qualityGateConfiguration = QualityGateConfiguration.builder()
+      .name("basic-coverage")
+      .description(
+        "A pragmatic balance of common expectations without requiring deep error validation."
+      )
+      .isPredefined(TRUE)
+      .build();
+
+    addAllOpenApiCriteria(
+      qualityGateConfiguration,
+      Stream.of(
+        PATH_COVERAGE,
+        HTTP_METHOD_COVERAGE,
+        OPERATION_SUCCESS_COVERAGE,
+        POSITIVE_RESPONSE_CODE_COVERAGE,
+        REQUIRED_PARAMETER_COVERAGE,
+        NO_UNDOCUMENTED_POSITIVE_RESPONSE_CODES
+      )
+    );
+
+    return qualityGateConfiguration;
+  }
+
+  private QualityGateConfiguration getFullFeature() {
+    var qualityGateConfiguration = QualityGateConfiguration.builder()
+      .name("full-feature")
+      .description(
+        "The most complete and strict configuration, useful for production-readiness or auditing."
+      )
+      .isPredefined(TRUE)
+      .build();
+
+    addAllOpenApiCriteria(
+      qualityGateConfiguration,
+      Stream.of(
+        PATH_COVERAGE,
+        HTTP_METHOD_COVERAGE,
+        OPERATION_SUCCESS_COVERAGE,
+        RESPONSE_CODE_COVERAGE,
+        ERROR_RESPONSE_CODE_COVERAGE,
+        POSITIVE_RESPONSE_CODE_COVERAGE,
+        REQUIRED_PARAMETER_COVERAGE,
+        OPTIONAL_PARAMETER_COVERAGE,
+        PARAMETER_COVERAGE,
+        CONTENT_TYPE_COVERAGE,
+        REQUIRED_ERROR_FIELDS_COVERAGE,
+        NO_UNDOCUMENTED_RESPONSE_CODES,
+        NO_UNDOCUMENTED_ERROR_RESPONSE_CODES,
+        NO_UNDOCUMENTED_POSITIVE_RESPONSE_CODES
+      )
+    );
+
+    return qualityGateConfiguration;
+  }
+
+  private QualityGateConfiguration getMinimal() {
+    var qualityGateConfiguration = QualityGateConfiguration.builder()
+      .name("minimal")
+      .description(
+        "Just enough to ensure the API is reachable at all expected endpoints."
+      )
+      .isPredefined(TRUE)
+      .build();
+
+    addAllOpenApiCriteria(qualityGateConfiguration, Stream.of(PATH_COVERAGE));
+
+    return qualityGateConfiguration;
+  }
+
+  private static QualityGateConfiguration getDryRun() {
+    return QualityGateConfiguration.builder()
+      .name("dry-run")
+      .description(
+        "Doesn't enforce any rules, but may be used to generate reports or test tooling."
+      )
+      .isPredefined(TRUE)
+      .build();
+  }
+
+  private void addAllOpenApiCriteria(
+    QualityGateConfiguration qualityGateConfiguration,
+    Stream<OpenApiCriteria> openApiCriteria
+  ) {
+    openApiCriteria
+      .map(openApiCriterion ->
+        openApiCoverageConfigurationRepository
+          .findByName(openApiCriterion.name())
+          .orElseThrow(IllegalStateException::new)
+      )
+      .map(openApiCoverageConfiguration ->
+        QualityGateOpenApiCoverageMapping.builder()
+          .openApiCoverageConfiguration(openApiCoverageConfiguration)
+          .qualityGateConfiguration(qualityGateConfiguration)
+          .build()
+      )
+      .forEach(mapping ->
+        qualityGateConfiguration.getOpenApiCoverageConfigurations().add(mapping)
+      );
+  }
+}

--- a/microservices/quality-gate-api/src/main/java/io/github/bbortt/snow/white/microservices/quality/gate/api/service/QualityGateService.java
+++ b/microservices/quality-gate-api/src/main/java/io/github/bbortt/snow/white/microservices/quality/gate/api/service/QualityGateService.java
@@ -6,31 +6,16 @@
 
 package io.github.bbortt.snow.white.microservices.quality.gate.api.service;
 
-import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.ERROR_RESPONSE_CODE_COVERAGE;
-import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.HTTP_METHOD_COVERAGE;
-import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.NO_UNDOCUMENTED_ERROR_RESPONSE_CODES;
-import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.NO_UNDOCUMENTED_POSITIVE_RESPONSE_CODES;
-import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.NO_UNDOCUMENTED_RESPONSE_CODES;
-import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.PARAMETER_COVERAGE;
-import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.PATH_COVERAGE;
-import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.REQUIRED_ERROR_FIELDS_COVERAGE;
-import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.REQUIRED_PARAMETER_COVERAGE;
-import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.RESPONSE_CODE_COVERAGE;
 import static java.lang.Boolean.FALSE;
-import static java.lang.Boolean.TRUE;
 import static org.springframework.util.CollectionUtils.isEmpty;
 
-import io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria;
 import io.github.bbortt.snow.white.microservices.quality.gate.api.api.rest.mapper.QualityGateConfigurationMapper;
 import io.github.bbortt.snow.white.microservices.quality.gate.api.domain.model.QualityGateConfiguration;
-import io.github.bbortt.snow.white.microservices.quality.gate.api.domain.model.QualityGateOpenApiCoverageMapping;
-import io.github.bbortt.snow.white.microservices.quality.gate.api.domain.repository.OpenApiCoverageConfigurationRepository;
 import io.github.bbortt.snow.white.microservices.quality.gate.api.domain.repository.QualityGateConfigurationRepository;
 import io.github.bbortt.snow.white.microservices.quality.gate.api.service.exception.ConfigurationDoesNotExistException;
 import io.github.bbortt.snow.white.microservices.quality.gate.api.service.exception.ConfigurationNameAlreadyExistsException;
 import io.github.bbortt.snow.white.microservices.quality.gate.api.service.exception.UnmodifiableConfigurationException;
 import java.util.List;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
@@ -47,7 +32,7 @@ public class QualityGateService {
 
   private final QualityGateConfigurationMapper qualityGateConfigurationMapper;
 
-  private final OpenApiCoverageConfigurationRepository openApiCoverageConfigurationRepository;
+  private final DefaultOpenApiQualityGates defaultOpenApiQualityGates;
   private final QualityGateConfigurationRepository qualityGateConfigurationRepository;
 
   @Transactional
@@ -147,12 +132,9 @@ public class QualityGateService {
       "Updating Quality-Gate configuration table with default values"
     );
 
-    var qualityGateConfigurations = Stream.of(
-      getBasicCoverage(),
-      getFullFeature(),
-      getMinimal(),
-      getDryRun()
-    )
+    var qualityGateConfigurations = defaultOpenApiQualityGates
+      .getDefaultOpenApiCoverageConfigurations()
+      .stream()
       .map(qualityGateConfiguration ->
         qualityGateConfigurationRepository
           .findByName(qualityGateConfiguration.getName())
@@ -166,101 +148,5 @@ public class QualityGateService {
       .toList();
 
     qualityGateConfigurationRepository.saveAll(qualityGateConfigurations);
-  }
-
-  private QualityGateConfiguration getBasicCoverage() {
-    var qualityGateConfiguration = QualityGateConfiguration.builder()
-      .name("basic-coverage")
-      .description(
-        "A pragmatic balance of common expectations without requiring deep error validation."
-      )
-      .isPredefined(TRUE)
-      .build();
-
-    addAllOpenApiCriteria(
-      qualityGateConfiguration,
-      Stream.of(
-        PATH_COVERAGE,
-        HTTP_METHOD_COVERAGE,
-        RESPONSE_CODE_COVERAGE,
-        REQUIRED_PARAMETER_COVERAGE,
-        NO_UNDOCUMENTED_RESPONSE_CODES
-      )
-    );
-
-    return qualityGateConfiguration;
-  }
-
-  private QualityGateConfiguration getFullFeature() {
-    var qualityGateConfiguration = QualityGateConfiguration.builder()
-      .name("full-feature")
-      .description(
-        "The most complete and strict configuration, useful for production-readiness or auditing."
-      )
-      .isPredefined(TRUE)
-      .build();
-
-    addAllOpenApiCriteria(
-      qualityGateConfiguration,
-      Stream.of(
-        PATH_COVERAGE,
-        HTTP_METHOD_COVERAGE,
-        RESPONSE_CODE_COVERAGE,
-        ERROR_RESPONSE_CODE_COVERAGE,
-        REQUIRED_PARAMETER_COVERAGE,
-        PARAMETER_COVERAGE,
-        REQUIRED_ERROR_FIELDS_COVERAGE,
-        NO_UNDOCUMENTED_RESPONSE_CODES,
-        NO_UNDOCUMENTED_ERROR_RESPONSE_CODES,
-        NO_UNDOCUMENTED_POSITIVE_RESPONSE_CODES
-      )
-    );
-
-    return qualityGateConfiguration;
-  }
-
-  private QualityGateConfiguration getMinimal() {
-    var qualityGateConfiguration = QualityGateConfiguration.builder()
-      .name("minimal")
-      .description(
-        "Just enough to ensure the API is reachable at all expected endpoints."
-      )
-      .isPredefined(TRUE)
-      .build();
-
-    addAllOpenApiCriteria(qualityGateConfiguration, Stream.of(PATH_COVERAGE));
-
-    return qualityGateConfiguration;
-  }
-
-  private static QualityGateConfiguration getDryRun() {
-    return QualityGateConfiguration.builder()
-      .name("dry-run")
-      .description(
-        "Doesn’t enforce any rules, but may be used to generate reports or test tooling."
-      )
-      .isPredefined(TRUE)
-      .build();
-  }
-
-  private void addAllOpenApiCriteria(
-    QualityGateConfiguration qualityGateConfiguration,
-    Stream<OpenApiCriteria> openApiCriteria
-  ) {
-    openApiCriteria
-      .map(openApiCriterion ->
-        openApiCoverageConfigurationRepository
-          .findByName(openApiCriterion.name())
-          .orElseThrow(IllegalStateException::new)
-      )
-      .map(openApiCoverageConfiguration ->
-        QualityGateOpenApiCoverageMapping.builder()
-          .openApiCoverageConfiguration(openApiCoverageConfiguration)
-          .qualityGateConfiguration(qualityGateConfiguration)
-          .build()
-      )
-      .forEach(mapping ->
-        qualityGateConfiguration.getOpenApiCoverageConfigurations().add(mapping)
-      );
   }
 }

--- a/microservices/quality-gate-api/src/test/java/io/github/bbortt/snow/white/microservices/quality/gate/api/service/DefaultOpenApiQualityGatesTest.java
+++ b/microservices/quality-gate-api/src/test/java/io/github/bbortt/snow/white/microservices/quality/gate/api/service/DefaultOpenApiQualityGatesTest.java
@@ -1,0 +1,94 @@
+package io.github.bbortt.snow.white.microservices.quality.gate.api.service;
+
+import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria.PATH_COVERAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+
+import io.github.bbortt.snow.white.commons.quality.gate.OpenApiCriteria;
+import io.github.bbortt.snow.white.microservices.quality.gate.api.domain.model.OpenApiCoverageConfiguration;
+import io.github.bbortt.snow.white.microservices.quality.gate.api.domain.repository.OpenApiCoverageConfigurationRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith({ MockitoExtension.class })
+class DefaultOpenApiQualityGatesTest {
+
+  @Mock
+  private OpenApiCoverageConfigurationRepository openApiCoverageConfigurationRepositoryMock;
+
+  private DefaultOpenApiQualityGates fixture;
+
+  @BeforeEach
+  void beforeEachSetup() {
+    fixture = new DefaultOpenApiQualityGates(
+      openApiCoverageConfigurationRepositoryMock
+    );
+  }
+
+  @Nested
+  class GetDefaultOpenApiCoverageConfigurationsTest {
+
+    @Test
+    void shouldContainFourQualityGateDefinitions() {
+      doAnswer(invocation ->
+        Optional.of(
+          OpenApiCoverageConfiguration.builder()
+            .name(invocation.getArgument(0))
+            .build()
+        )
+      )
+        .when(openApiCoverageConfigurationRepositoryMock)
+        .findByName(anyString());
+
+      assertThat(fixture.getDefaultOpenApiCoverageConfigurations())
+        .allSatisfy(qualityGateConfiguration ->
+          assertThat(qualityGateConfiguration.getIsPredefined()).isTrue()
+        )
+        .satisfiesExactly(
+          // basic-coverage
+          qualityGateConfiguration ->
+            assertThat(
+              qualityGateConfiguration.getOpenApiCoverageConfigurations()
+            ).hasSize(6),
+          // full-feature
+          qualityGateConfiguration ->
+            assertThat(
+              qualityGateConfiguration.getOpenApiCoverageConfigurations()
+            ).hasSize(OpenApiCriteria.values().length),
+          // minimal
+          qualityGateConfiguration ->
+            assertThat(
+              qualityGateConfiguration.getOpenApiCoverageConfigurations()
+            ).satisfiesExactly(configuration ->
+              assertThat(
+                configuration.getOpenApiCoverageConfiguration().getName()
+              ).isEqualTo(PATH_COVERAGE.name())
+            ),
+          // dry-run
+          qualityGateConfiguration ->
+            assertThat(
+              qualityGateConfiguration.getOpenApiCoverageConfigurations()
+            ).isEmpty()
+        );
+    }
+
+    @Test
+    void shouldResultInExceptionWhenOpenApiConfigurationsDoNotExist() {
+      assertThatThrownBy(() ->
+        fixture.getDefaultOpenApiCoverageConfigurations()
+      ).isInstanceOf(IllegalStateException.class);
+
+      verify(openApiCoverageConfigurationRepositoryMock).findByName(
+        anyString()
+      );
+    }
+  }
+}

--- a/microservices/quality-gate-api/src/test/java/io/github/bbortt/snow/white/microservices/quality/gate/api/service/QualityGateServiceTest.java
+++ b/microservices/quality-gate-api/src/test/java/io/github/bbortt/snow/white/microservices/quality/gate/api/service/QualityGateServiceTest.java
@@ -29,11 +29,11 @@ import io.github.bbortt.snow.white.microservices.quality.gate.api.api.rest.mappe
 import io.github.bbortt.snow.white.microservices.quality.gate.api.domain.model.OpenApiCoverageConfiguration;
 import io.github.bbortt.snow.white.microservices.quality.gate.api.domain.model.QualityGateConfiguration;
 import io.github.bbortt.snow.white.microservices.quality.gate.api.domain.model.QualityGateOpenApiCoverageMapping;
-import io.github.bbortt.snow.white.microservices.quality.gate.api.domain.repository.OpenApiCoverageConfigurationRepository;
 import io.github.bbortt.snow.white.microservices.quality.gate.api.domain.repository.QualityGateConfigurationRepository;
 import io.github.bbortt.snow.white.microservices.quality.gate.api.service.exception.ConfigurationDoesNotExistException;
 import io.github.bbortt.snow.white.microservices.quality.gate.api.service.exception.ConfigurationNameAlreadyExistsException;
 import io.github.bbortt.snow.white.microservices.quality.gate.api.service.exception.UnmodifiableConfigurationException;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -57,7 +57,7 @@ class QualityGateServiceTest {
   private QualityGateConfigurationMapper qualityGateConfigurationMapperMock;
 
   @Mock
-  private OpenApiCoverageConfigurationRepository openApiCoverageConfigurationRepositoryMock;
+  private DefaultOpenApiQualityGates defaultOpenApiQualityGatesMock;
 
   @Mock
   private QualityGateConfigurationRepository qualityGateConfigurationRepositoryMock;
@@ -68,7 +68,7 @@ class QualityGateServiceTest {
   void beforeEachSetup() {
     fixture = new QualityGateService(
       qualityGateConfigurationMapperMock,
-      openApiCoverageConfigurationRepositoryMock,
+      defaultOpenApiQualityGatesMock,
       qualityGateConfigurationRepositoryMock
     );
   }
@@ -346,7 +346,9 @@ class QualityGateServiceTest {
 
     @Test
     void shouldUpdatePersistedQualityGateConfigurations() {
-      doReturnOpenApiCoverageConfigurationByNameUponMockInvocation();
+      doReturn(buildDefaultConfigurations())
+        .when(defaultOpenApiQualityGatesMock)
+        .getDefaultOpenApiCoverageConfigurations();
 
       doAnswer(invocationOnMock ->
         Optional.of(
@@ -379,15 +381,13 @@ class QualityGateServiceTest {
       verify(qualityGateConfigurationRepositoryMock, times(4)).findByName(
         anyString()
       );
-
-      verify(openApiCoverageConfigurationRepositoryMock, times(16)).findByName(
-        anyString()
-      );
     }
 
     @Test
     void shouldPersistQualityGateConfigurationsIfNoneExistYet() {
-      doReturnOpenApiCoverageConfigurationByNameUponMockInvocation();
+      doReturn(buildDefaultConfigurations())
+        .when(defaultOpenApiQualityGatesMock)
+        .getDefaultOpenApiCoverageConfigurations();
 
       doReturn(Optional.empty())
         .when(qualityGateConfigurationRepositoryMock)
@@ -411,22 +411,39 @@ class QualityGateServiceTest {
       verify(qualityGateConfigurationRepositoryMock, times(4)).findByName(
         anyString()
       );
-
-      verify(openApiCoverageConfigurationRepositoryMock, times(16)).findByName(
-        anyString()
-      );
     }
 
-    private void doReturnOpenApiCoverageConfigurationByNameUponMockInvocation() {
-      doAnswer(invocationOnMock ->
-        Optional.of(
-          OpenApiCoverageConfiguration.builder()
-            .name(invocationOnMock.getArgument(0))
-            .build()
-        )
-      )
-        .when(openApiCoverageConfigurationRepositoryMock)
-        .findByName(anyString());
+    private Set<QualityGateConfiguration> buildDefaultConfigurations() {
+      var gates = new LinkedHashSet<QualityGateConfiguration>();
+      gates.add(gateWithCriteria("basic-coverage", 6));
+      gates.add(gateWithCriteria("full-feature", 14));
+      gates.add(gateWithCriteria("minimal", 1));
+      gates.add(gateWithNoCriteria("dry-run"));
+      return gates;
+    }
+
+    private QualityGateConfiguration gateWithCriteria(
+      String name,
+      int criteriaCount
+    ) {
+      var config = QualityGateConfiguration.builder().name(name).build();
+      for (int i = 0; i < criteriaCount; i++) {
+        config
+          .getOpenApiCoverageConfigurations()
+          .add(
+            QualityGateOpenApiCoverageMapping.builder()
+              .qualityGateConfiguration(config)
+              .openApiCoverageConfiguration(
+                OpenApiCoverageConfiguration.builder().build()
+              )
+              .build()
+          );
+      }
+      return config;
+    }
+
+    private QualityGateConfiguration gateWithNoCriteria(String name) {
+      return QualityGateConfiguration.builder().name(name).build();
     }
 
     private void assertThatAllStandardQualityGateConfigurationsWerePersisted(
@@ -438,12 +455,12 @@ class QualityGateServiceTest {
           qualityGateConfiguration ->
             assertThat(qualityGateConfiguration).satisfies(
               c -> assertThat(c.getName()).isEqualTo("basic-coverage"),
-              c -> assertThat(c.getOpenApiCoverageConfigurations()).hasSize(5)
+              c -> assertThat(c.getOpenApiCoverageConfigurations()).hasSize(6)
             ),
           qualityGateConfiguration ->
             assertThat(qualityGateConfiguration).satisfies(
               c -> assertThat(c.getName()).isEqualTo("full-feature"),
-              c -> assertThat(c.getOpenApiCoverageConfigurations()).hasSize(10)
+              c -> assertThat(c.getOpenApiCoverageConfigurations()).hasSize(14)
             ),
           qualityGateConfiguration ->
             assertThat(qualityGateConfiguration).satisfies(

--- a/toolkit/cli/src/actions/upload-prereleases/index.ts
+++ b/toolkit/cli/src/actions/upload-prereleases/index.ts
@@ -62,8 +62,6 @@ export const uploadPrereleases = async (apiIndexApi: ApiIndexApi, options: Uploa
       uploadedMetadata = apiSpecMetadata.metadata;
       await uploadApiSpec(apiSpecMetadata.metadata, content, url, apiIndexApi, file);
 
-      console.log('uploadedMetadata after:', uploadedMetadata);
-
       successCount++;
     } catch (error: unknown) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
reviewed `OpenApiCriteria`. **new**:
* `OPERATION_SUCCESS_COVERAGE`: Each operation (unique path + HTTP method combination) has produced at least one successful (2xx) response. Complements `HTTP_METHOD_COVERAGE`, which only checks that an operation was called at all.
* `POSITIVE_RESPONSE_CODE_COVERAGE`: Each documented positive (non-error) response code (1xx, 2xx, 3xx) for each endpoint is tested. This is a subset of `RESPONSE_CODE_COVERAGE`.
* `OPTIONAL_PARAMETER_COVERAGE`: Each optional (non-required) parameter (in path, query) has been tested with valid values. This is a subset of `PARAMETER_COVERAGE`.
* `CONTENT_TYPE_COVERAGE`: Each documented request body content type (e.g. `application/json`, `multipart/form-data`) for each endpoint has been exercised.