### PR TITLE
custom public host mapping for Helm

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -27,6 +27,8 @@ docs:
         url: /cli/
   - title: 'Reference'
     children:
+      - title: 'Quality Gate Criteria'
+        url: /quality-gate-criteria/
       - title: 'Requirements'
         url: /requirements/
       - title: 'License'

--- a/docs/_pages/onboarding.md
+++ b/docs/_pages/onboarding.md
@@ -206,6 +206,7 @@ The Snow-White UI shows:
 
 Snow-White ships with a `basic-coverage` gate out of the box.
 Custom gates can be configured via the UI or API.
+See [Quality Gate Criteria](/quality-gate-criteria/) for the full list of available checks.
 
 ## Checklist
 

--- a/docs/_pages/quality-gate-criteria.md
+++ b/docs/_pages/quality-gate-criteria.md
@@ -1,0 +1,105 @@
+---
+title: 'Quality Gate Criteria'
+permalink: /quality-gate-criteria/
+toc: true
+toc_sticky: true
+---
+
+Quality gate criteria are the individual checks Snow-White evaluates when running an analysis.
+Each criterion compares what your API specification declares against what your runtime telemetry actually observed.
+
+## Specification Format Support
+
+Snow-White currently evaluates criteria against **OpenAPI specifications** (v3.x).
+Support for additional specification formats — most notably **AsyncAPI** for event-driven APIs — is planned.
+The criteria model itself is format-agnostic by design, so new formats slot in without changing how quality gates are defined or evaluated.
+
+## Available Criteria
+
+### Path Coverage
+
+Every path defined in the specification has been called.
+This is a subset of [HTTP Method Coverage](#http-method-coverage).
+
+### HTTP Method Coverage
+
+Each HTTP method (`GET`, `POST`, `PUT`, `DELETE`, etc.) for each path has been tested.
+
+### Operation Success Coverage
+
+Each operation (unique path + HTTP method combination) has produced at least one successful (2xx) response.
+Complements [HTTP Method Coverage](#http-method-coverage), which only checks that an operation was called at all.
+
+### Error Response Code Coverage
+
+Each documented error response code for each endpoint is tested.
+This is a subset of [Response Code Coverage](#response-code-coverage).
+
+### Positive Response Code Coverage
+
+Each documented positive (non-error) response code (1xx, 2xx, 3xx) for each endpoint is tested.
+This is a subset of [Response Code Coverage](#response-code-coverage).
+
+### Response Code Coverage
+
+Each documented response code for each endpoint is tested.
+
+### Required Parameter Coverage
+
+Each required parameter (in path, query) has been tested with valid values.
+This is a subset of [Parameter Coverage](#parameter-coverage).
+
+### Optional Parameter Coverage
+
+Each optional (non-required) parameter (in path, query) has been tested with valid values.
+This is a subset of [Parameter Coverage](#parameter-coverage).
+
+### Parameter Coverage
+
+Each parameter (in path, query) has been tested with valid values.
+
+### Content Type Coverage
+
+Each documented request body content type (e.g. `application/json`, `multipart/form-data`) for each endpoint has been exercised.
+
+### Required Error Fields Coverage
+
+Error responses include all required fields as declared in the specification.
+
+### All Response Codes must be Specified
+
+All response codes (including errors) that occurred must be documented in the specification.
+Catches undocumented behavior before it reaches production.
+
+### All Error Response Codes must be Specified
+
+All error response codes that occurred must be documented in the specification.
+This is a subset of [All Response Codes must be Specified](#all-response-codes-must-be-specified).
+
+### All Non-Erroneous Response Codes must be Specified
+
+All response codes that occurred and are not being considered errors (0–399) must be documented in the specification.
+This is a subset of [All Response Codes must be Specified](#all-response-codes-must-be-specified).
+
+## Criteria Relationships
+
+Several criteria form a hierarchy — satisfying a broader criterion implies narrower ones were also satisfied:
+
+```plaintext
+RESPONSE_CODE_COVERAGE
+├── POSITIVE_RESPONSE_CODE_COVERAGE
+└── ERROR_RESPONSE_CODE_COVERAGE
+
+NO_UNDOCUMENTED_RESPONSE_CODES
+├── NO_UNDOCUMENTED_POSITIVE_RESPONSE_CODES
+└── NO_UNDOCUMENTED_ERROR_RESPONSE_CODES
+
+PARAMETER_COVERAGE
+├── REQUIRED_PARAMETER_COVERAGE
+└── OPTIONAL_PARAMETER_COVERAGE
+
+HTTP_METHOD_COVERAGE
+└── PATH_COVERAGE
+```
+
+Understanding these relationships helps when composing custom quality gates: requiring a parent criterion already implies its subsets.

--- a/docs/_pages/workflows.md
+++ b/docs/_pages/workflows.md
@@ -85,3 +85,5 @@ Add the coverage check as a CI step after your integration tests.
 ```
 
 The step will fail the workflow if the quality gate is not met, preventing the PR from merging.
+
+See [Quality Gate Criteria](/quality-gate-criteria/) for the full list of checks available to include in a gate.

--- a/helm/DEVELOPMENT.md
+++ b/helm/DEVELOPMENT.md
@@ -34,6 +34,7 @@ helm upgrade --install \
   --set image.pullPolicy=IfNotPresent \
   --set snowWhite.mode=minimal \
   --set snowWhite.host=localhost \
+  --set snowWhite.ingress.enabled=true \
   --set snowWhite.ingress.tls=false \
   --set snowWhite.apiIndexApi.image.tag=latest \
   --set snowWhite.apiGateway.image.tag=latest \

--- a/helm/charts/snow-white/README.md
+++ b/helm/charts/snow-white/README.md
@@ -133,9 +133,10 @@ A Helm chart for deploying [`snow-white`](https://github.com/bbortt/snow-white).
 
 ### Global Settings
 
-| Key            | Type   | Default | Description                                                                                                                          |
-| -------------- | ------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| snowWhite.host | string | `""`    | Public domain where Snow-White is reachable under. Must be specified when either `ingress.enabled=true` or `httproute.enabled=true`. |
+| Key                     | Type   | Default | Description                                                                                                                                                                   |
+| ----------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| snowWhite.host          | string | `""`    | Public domain where Snow-White is reachable under. Must be specified when either `ingress.enabled=true` or `httproute.enabled=true`.                                          |
+| snowWhite.publicAddress | string | `""`    | Public URL where Snow-White is reachable under. If `snowWhite.host` is not the public URL (e.g. `HTTPRoute` runs on different port than 80/443), specify the public URL here. |
 
 ### Housekeeping
 

--- a/helm/charts/snow-white/templates/_helpers.tpl
+++ b/helm/charts/snow-white/templates/_helpers.tpl
@@ -52,6 +52,19 @@ imagePullSecrets:
 {{- end -}}
 
 {{/*
+Helper function printing the address where Snow-White is reachable from
+*/}}
+{{- define "snow-white.publicAddress" -}}
+{{- if not (empty .Values.snowWhite.publicAddress) -}}
+{{ .Values.snowWhite.publicAddress }}
+{{- else if or .Values.snowWhite.ingress.tls .Values.snowWhite.httproute.enabled -}}
+https://{{ include "snow-white.publicHost" . }}
+{{- else -}}
+http://{{ include "snow-white.publicHost" . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Helper function making sure that the public domain (exposed through ingress) is defined
 */}}
 {{- define "snow-white.publicHost" -}}

--- a/helm/charts/snow-white/templates/api-gateway.yaml
+++ b/helm/charts/snow-white/templates/api-gateway.yaml
@@ -47,11 +47,7 @@ spec:
           env:
           {{- include "snow-white.commonPodEnvironmentVariables" . | nindent 12 }}
             - name: 'SNOW_WHITE_API_GATEWAY_PUBLIC-URL'
-              {{- if .Values.snowWhite.ingress.tls }}
-              value: 'https://{{ include "snow-white.publicHost" . }}'
-              {{- else }}
-              value: 'http://{{ include "snow-white.publicHost" . }}'
-              {{- end }}
+              value: '{{ include "snow-white.publicAddress" . }}'
             - name: 'SNOW_WHITE_API_GATEWAY_API-INDEX-API-URL'
               value: 'http://{{ include "snow-white.name" (dict "name" "api-index-api" "context" .) }}.{{ include "common.names.namespace" . }}.svc.cluster.local.:80'
             - name: 'SNOW_WHITE_API_GATEWAY_QUALITY-GATE-API-URL'

--- a/helm/charts/snow-white/templates/api-index-api.yaml
+++ b/helm/charts/snow-white/templates/api-index-api.yaml
@@ -46,11 +46,7 @@ spec:
           env:
           {{- include "snow-white.commonNativePodEnvironmentVariables" . | nindent 12 }}
             - name: 'SNOW_WHITE_API_INDEX_PUBLIC_API_GATEWAY_URL'
-              {{- if or .Values.snowWhite.httproute.enabled .Values.snowWhite.ingress.tls }}
-              value: 'https://{{ include "snow-white.publicHost" . }}'
-              {{- else }}
-              value: 'http://{{ include "snow-white.publicHost" . }}'
-              {{- end }}
+              value: '{{ include "snow-white.publicAddress" . }}'
           {{- if .Values.postgresql.enabled }}
             - name: 'SPRING_DATASOURCE_URL'
               value: 'jdbc:postgresql://{{ printf "%s-%s" .Release.Name "postgresql" }}.{{ include "common.names.namespace" . }}.svc.cluster.local.:5432/api-index-api'

--- a/helm/charts/snow-white/templates/quality-gate-api.yaml
+++ b/helm/charts/snow-white/templates/quality-gate-api.yaml
@@ -46,11 +46,7 @@ spec:
           env:
           {{- include "snow-white.commonNativePodEnvironmentVariables" . | nindent 12 }}
             - name: 'SNOW_WHITE_QUALITY_GATE_API_PUBLIC-API-GATEWAY-URL'
-              {{- if or .Values.snowWhite.httproute.enabled .Values.snowWhite.ingress.tls }}
-              value: 'https://{{ include "snow-white.publicHost" . }}'
-              {{- else }}
-              value: 'http://{{ include "snow-white.publicHost" . }}'
-              {{- end }}
+              value: '{{ include "snow-white.publicAddress" . }}'
           {{- if .Values.postgresql.enabled }}
             - name: 'SPRING_DATASOURCE_URL'
               value: 'jdbc:postgresql://{{ printf "%s-%s" .Release.Name "postgresql" }}.{{ include "common.names.namespace" . }}.svc.cluster.local.:5432/quality-gate-api'

--- a/helm/charts/snow-white/templates/report-coordinator-api.yaml
+++ b/helm/charts/snow-white/templates/report-coordinator-api.yaml
@@ -54,11 +54,7 @@ spec:
             - name: 'SNOW_WHITE_REPORT_COORDINATOR_API_OPENAPI-CALCULATION-RESPONSE_TOPIC'
               value: '{{ .Values.snowWhite.kafka.openapiCalculationResponseTopic }}'
             - name: 'SNOW_WHITE_REPORT_COORDINATOR_API_PUBLIC_API_GATEWAY_URL'
-              {{- if or .Values.snowWhite.httproute.enabled .Values.snowWhite.ingress.tls }}
-              value: 'https://{{ include "snow-white.publicHost" . }}'
-              {{- else }}
-              value: 'http://{{ include "snow-white.publicHost" . }}'
-              {{- end }}
+              value: '{{ include "snow-white.publicAddress" . }}'
             - name: 'SNOW_WHITE_REPORT_COORDINATOR_API_QUALITY-GATE-API_BASE-URL'
               value: 'http://{{ include "snow-white.name" (dict "name" "quality-gate-api" "context" .) }}.{{ include "common.names.namespace" . }}.svc.cluster.local.:80'
             - name: 'SPRING_KAFKA_BOOTSTRAP_SERVERS'

--- a/helm/charts/snow-white/values.yaml
+++ b/helm/charts/snow-white/values.yaml
@@ -62,6 +62,11 @@ snowWhite:
   # @section -- Global Settings
   host: ''
 
+  # -- Public URL where Snow-White is reachable under.
+  # If `snowWhite.host` is not the public URL (e.g. `HTTPRoute` runs on different port than 80/443), specify the public URL here.
+  # @section -- Global Settings
+  publicAddress: ''
+
   # -- Deployment mode of Snow-White.
   # Allowed values: `minimal`, `high-available`, `autoscale`.
   # @section -- Availability

--- a/helm/test/api-gateway.spec.ts
+++ b/helm/test/api-gateway.spec.ts
@@ -4,11 +4,9 @@
  * See LICENSE file for full details.
  */
 
-import { describe, it, expect } from 'vitest';
-import { parseDocument } from 'yaml';
+import { describe, expect, it } from 'vitest';
 import { renderHelmChart } from './render-helm-chart';
 import {
-  expectFailsWithMessageContaining,
   expectToHaveDefaultLabelsForMicroservice,
   getPodSpec,
   getTemplateMetadata,
@@ -483,7 +481,11 @@ describe('API Gateway', () => {
                 chartPath: 'charts/snow-white',
                 values: {
                   snowWhite: {
+                    httproute: {
+                      enabled: false,
+                    },
                     ingress: {
+                      enabled: true,
                       tls: false,
                     },
                   },
@@ -499,6 +501,31 @@ describe('API Gateway', () => {
           });
 
           it('should include public url from values with TLS', async () => {
+            const apiGateway = await renderAndGetApiGatewayContainer(
+              await renderHelmChart({
+                chartPath: 'charts/snow-white',
+                values: {
+                  snowWhite: {
+                    httproute: {
+                      enabled: false,
+                    },
+                    ingress: {
+                      enabled: true,
+                      tls: true,
+                    },
+                  },
+                },
+              }),
+            );
+
+            const publicDomain = apiGateway.env.find(
+              (env) => env.name === 'SNOW_WHITE_API_GATEWAY_PUBLIC-URL',
+            );
+            expect(publicDomain).toBeDefined();
+            expect(publicDomain.value).toBe('https://localhost');
+          });
+
+          it('should include public url from values where HTTPRoute is enabled', async () => {
             const apiGateway = await renderAndGetApiGatewayContainer();
 
             const publicDomain = apiGateway.env.find(
@@ -506,6 +533,26 @@ describe('API Gateway', () => {
             );
             expect(publicDomain).toBeDefined();
             expect(publicDomain.value).toBe('https://localhost');
+          });
+
+          it('should include public url from values with custom address', async () => {
+            const publicAddress = 'prefix.suffix:1234';
+            const apiGateway = await renderAndGetApiGatewayContainer(
+              await renderHelmChart({
+                chartPath: 'charts/snow-white',
+                values: {
+                  snowWhite: {
+                    publicAddress,
+                  },
+                },
+              }),
+            );
+
+            const publicDomain = apiGateway.env.find(
+              (env) => env.name === 'SNOW_WHITE_API_GATEWAY_PUBLIC-URL',
+            );
+            expect(publicDomain).toBeDefined();
+            expect(publicDomain.value).toBe(publicAddress);
           });
 
           it('should calculate service connections based on release name', async () => {

--- a/helm/test/api-index-api.spec.ts
+++ b/helm/test/api-index-api.spec.ts
@@ -547,6 +547,27 @@ describe('API Index API', () => {
             expect(publicApiGatewayUrl.value).toBe('https://custom-host');
           });
 
+          it('should include public url from values with custom address', async () => {
+            const publicAddress = 'prefix.suffix:1234';
+            const qualityGateApi = await renderAndGetApiIndexApiContainer(
+              await renderHelmChart({
+                chartPath: 'charts/snow-white',
+                values: {
+                  snowWhite: {
+                    publicAddress,
+                  },
+                },
+              }),
+            );
+
+            const publicApiGatewayUrl = qualityGateApi.env.find(
+              (env) =>
+                env.name === 'SNOW_WHITE_API_INDEX_PUBLIC_API_GATEWAY_URL',
+            );
+            expect(publicApiGatewayUrl).toBeDefined();
+            expect(publicApiGatewayUrl.value).toBe(publicAddress);
+          });
+
           it('should calculate jdbc connection string', async () => {
             const apiIndexApi = await renderAndGetApiIndexApiContainer();
 

--- a/helm/test/ingress.spec.ts
+++ b/helm/test/ingress.spec.ts
@@ -4,23 +4,35 @@
  * See LICENSE file for full details.
  */
 
-import { renderHelmChart } from './render-helm-chart';
+import {
+  HelmChartRenderParameters,
+  renderHelmChart as originalRenderHelmChart,
+} from './render-helm-chart';
 import { expectToHaveDefaultLabelsForMicroservice } from './helpers';
+import { merge } from 'lodash';
 
-const valuesWithIngress = {
-  snowWhite: {
-    ingress: {
-      enabled: true,
-    },
-  },
-};
+const renderHelmChart = (options: HelmChartRenderParameters): Promise<any[]> =>
+  originalRenderHelmChart({
+    ...merge(
+      {
+        values: {
+          snowWhite: {
+            host: 'localhost',
+            httproute: { enabled: false },
+            ingress: { enabled: true },
+          },
+        },
+        withDefaultValues: false,
+      },
+      options,
+    ),
+  });
 
 describe('Ingress', () => {
   const renderAndGetIngress = async (manifests?: any[]) => {
     if (!manifests) {
       manifests = await renderHelmChart({
         chartPath: 'charts/snow-white',
-        values: valuesWithIngress,
       });
     }
 
@@ -53,7 +65,6 @@ describe('Ingress', () => {
   it('should be the only exposed ingress', async () => {
     const manifests = await renderHelmChart({
       chartPath: 'charts/snow-white',
-      values: valuesWithIngress,
     });
 
     const ingress = manifests.filter((m) => m.kind === 'Ingress');
@@ -67,7 +78,6 @@ describe('Ingress', () => {
       chartPath: 'charts/snow-white',
       // 53 chars is the max length for Helm release names
       releaseName: 'very-long-test-release-name-that-exceeds-the-limit-12',
-      values: valuesWithIngress,
     });
 
     const ingress = manifests.find(
@@ -82,7 +92,7 @@ describe('Ingress', () => {
 
   it('is disabled by default', async () => {
     await expect(() =>
-      renderHelmChart({
+      originalRenderHelmChart({
         chartPath: 'charts/snow-white',
         withDefaultValues: false,
       }),
@@ -93,7 +103,7 @@ describe('Ingress', () => {
 
   it('should throw error when Ingress is enabled but no public domain is set', async () => {
     await expect(() =>
-      renderHelmChart({
+      originalRenderHelmChart({
         chartPath: 'charts/snow-white',
         values: {
           snowWhite: {
@@ -247,7 +257,6 @@ describe('Ingress', () => {
         await renderHelmChart({
           chartPath: 'charts/snow-white',
           values: {
-            ...valuesWithIngress,
             otelCollector: {
               exposeThroughApiGateway: false,
             },

--- a/helm/test/render-helm-chart.ts
+++ b/helm/test/render-helm-chart.ts
@@ -12,7 +12,6 @@ import { merge } from 'lodash';
 
 const mergeWithDefaultValues = (values: object): object => {
   return {
-    appVersionOverride: 'test-version',
     ...merge(
       {
         snowWhite: {
@@ -46,14 +45,18 @@ const transformStdoutToJson = async (
   return json;
 };
 
-export const renderHelmChart = async (options: {
+export interface HelmChartRenderParameters {
   chartPath: string;
   debug?: boolean;
   namespace?: string;
   releaseName?: string;
   values?: object;
   withDefaultValues?: boolean;
-}): Promise<any[]> => {
+}
+
+export const renderHelmChart = async (
+  options: HelmChartRenderParameters,
+): Promise<any[]> => {
   const {
     chartPath,
     debug = process.env.DEBUG?.toLowerCase() === 'true',
@@ -66,7 +69,10 @@ export const renderHelmChart = async (options: {
   const { path: tmpValuesPath } = await tmpFile();
   await writeFile(
     tmpValuesPath,
-    stringify(withDefaultValues ? mergeWithDefaultValues(values) : values),
+    stringify({
+      appVersionOverride: 'test-version',
+      ...(withDefaultValues ? mergeWithDefaultValues(values) : values),
+    }),
   );
 
   const helmArgs = [

--- a/helm/test/report-coordinator-api.spec.ts
+++ b/helm/test/report-coordinator-api.spec.ts
@@ -504,7 +504,7 @@ describe('Report Coordinator API', () => {
           });
 
           it('should include public host configuration with tls enabled', async () => {
-            const qualityGateApi =
+            const reportCoordinatorApi =
               await renderAndGetReportCoordinatorApiContainer(
                 await renderHelmChart({
                   chartPath: 'charts/snow-white',
@@ -516,7 +516,7 @@ describe('Report Coordinator API', () => {
                 }),
               );
 
-            const publicApiGatewayUrl = qualityGateApi.env.find(
+            const publicApiGatewayUrl = reportCoordinatorApi.env.find(
               (env) =>
                 env.name ===
                 'SNOW_WHITE_REPORT_COORDINATOR_API_PUBLIC_API_GATEWAY_URL',
@@ -526,7 +526,7 @@ describe('Report Coordinator API', () => {
           });
 
           it('should include public host configuration with tls disabled', async () => {
-            const qualityGateApi =
+            const reportCoordinatorApi =
               await renderAndGetReportCoordinatorApiContainer(
                 await renderHelmChart({
                   chartPath: 'charts/snow-white',
@@ -543,7 +543,7 @@ describe('Report Coordinator API', () => {
                 }),
               );
 
-            const publicApiGatewayUrl = qualityGateApi.env.find(
+            const publicApiGatewayUrl = reportCoordinatorApi.env.find(
               (env) =>
                 env.name ===
                 'SNOW_WHITE_REPORT_COORDINATOR_API_PUBLIC_API_GATEWAY_URL',
@@ -553,7 +553,7 @@ describe('Report Coordinator API', () => {
           });
 
           it('should include public host configuration with tls disabled but HTTPRoute enabled', async () => {
-            const qualityGateApi =
+            const reportCoordinatorApi =
               await renderAndGetReportCoordinatorApiContainer(
                 await renderHelmChart({
                   chartPath: 'charts/snow-white',
@@ -571,7 +571,7 @@ describe('Report Coordinator API', () => {
                 }),
               );
 
-            const publicApiGatewayUrl = qualityGateApi.env.find(
+            const publicApiGatewayUrl = reportCoordinatorApi.env.find(
               (env) =>
                 env.name ===
                 'SNOW_WHITE_REPORT_COORDINATOR_API_PUBLIC_API_GATEWAY_URL',
@@ -580,18 +580,41 @@ describe('Report Coordinator API', () => {
             expect(publicApiGatewayUrl.value).toBe('https://custom-host');
           });
 
+          it('should include public url from values with custom address', async () => {
+            const publicAddress = 'prefix.suffix:1234';
+            const reportCoordinatorApi =
+              await renderAndGetReportCoordinatorApiContainer(
+                await renderHelmChart({
+                  chartPath: 'charts/snow-white',
+                  values: {
+                    snowWhite: {
+                      publicAddress,
+                    },
+                  },
+                }),
+              );
+
+            const publicApiGatewayUrl = reportCoordinatorApi.env.find(
+              (env) =>
+                env.name ===
+                'SNOW_WHITE_REPORT_COORDINATOR_API_PUBLIC_API_GATEWAY_URL',
+            );
+            expect(publicApiGatewayUrl).toBeDefined();
+            expect(publicApiGatewayUrl.value).toBe(publicAddress);
+          });
+
           it('should calculate quality-gate-api connection string', async () => {
             const reportCoordinatorApi =
               await renderAndGetReportCoordinatorApiContainer();
 
-            const qualityGateApiUrl = reportCoordinatorApi.env.find(
+            const reportCoordinatorApiUrl = reportCoordinatorApi.env.find(
               (env) =>
                 env.name ===
                 'SNOW_WHITE_REPORT_COORDINATOR_API_QUALITY-GATE-API_BASE-URL',
             );
-            expect(qualityGateApiUrl).toBeDefined();
+            expect(reportCoordinatorApiUrl).toBeDefined();
 
-            expect(qualityGateApiUrl.value).toBe(
+            expect(reportCoordinatorApiUrl.value).toBe(
               'http://snow-white-quality-gate-api-test-release.default.svc.cluster.local.:80',
             );
           });
@@ -737,7 +760,7 @@ describe('Report Coordinator API', () => {
                     apiIndexApi: {
                       additionalEnvs: onPremDatasourceProperties,
                     },
-                    qualityGateApi: {
+                    reportCoordinatorApi: {
                       additionalEnvs: onPremDatasourceProperties,
                     },
                     reportCoordinatorApi: {
@@ -765,7 +788,7 @@ describe('Report Coordinator API', () => {
                     apiIndexApi: {
                       additionalEnvs: onPremDatasourceProperties,
                     },
-                    qualityGateApi: {
+                    reportCoordinatorApi: {
                       additionalEnvs: onPremDatasourceProperties,
                     },
                     reportCoordinatorApi: {

--- a/microservices/api-gateway/src/main/webapp/app/shared/layout/footer/footer.tsx
+++ b/microservices/api-gateway/src/main/webapp/app/shared/layout/footer/footer.tsx
@@ -19,7 +19,7 @@ const Footer = () => {
         <Col md="4" className="text-center text-md-start mb-2 mb-md-0">
           <h5>Snow-White</h5>
           <p className="small text-muted mb-0">
-            &copy; {currentYear} Timon Borter. &nbsp;
+            &copy; {currentYear} Timon Borter.
             <Translate contentKey="footer.rights">All rights reserved.</Translate>
           </p>
           <p className="small text-muted">

--- a/microservices/openapi-coverage-stream/src/main/resources/config/application.yaml
+++ b/microservices/openapi-coverage-stream/src/main/resources/config/application.yaml
@@ -1,3 +1,6 @@
+logging:
+  level:
+    org.apache.kafka.clients.admin.internals.AdminMetadataManager: WARN
 spring:
   application:
     name: openapi-coverage-stream

--- a/microservices/otel-event-filter-stream/src/main/resources/config/application.yaml
+++ b/microservices/otel-event-filter-stream/src/main/resources/config/application.yaml
@@ -1,3 +1,6 @@
+logging:
+  level:
+    org.apache.kafka.clients.admin.internals.AdminMetadataManager: WARN
 management:
   opentelemetry:
     resource-attributes:


### PR DESCRIPTION
custom value `snowWhite.publicAddress` overrules all automatic public address calculations.
that is especially useful if your `Ingress` or `HTTPRoute` run on different ports than 80 or 443.