### PR TITLE
update package manager pnpm to v11

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -11,5 +11,5 @@
     "@playwright/test": "^1.58.2",
     "@types/node": "^25.5.0"
   },
-  "packageManager": "pnpm@10.29.1"
+  "packageManager": "pnpm@11.1.2"
 }

--- a/helm/package.json
+++ b/helm/package.json
@@ -27,7 +27,7 @@
   "optionalDependencies": {
     "npm-check-updates": "22.1.1"
   },
-  "packageManager": "pnpm@10.29.1",
+  "packageManager": "pnpm@11.1.2",
   "engines": {
     "node": ">=22.14.0"
   },

--- a/helm/pnpm-workspace.yaml
+++ b/helm/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/microservices/api-gateway/package.json
+++ b/microservices/api-gateway/package.json
@@ -144,7 +144,7 @@
   "optionalDependencies": {
     "npm-check-updates": "22.2.0"
   },
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.1.2",
   "engines": {
     "node": ">=22.14.0"
   },

--- a/microservices/api-gateway/pnpm-workspace.yaml
+++ b/microservices/api-gateway/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  '@parcel/watcher': false
+  unrs-resolver: false

--- a/microservices/api-index-api/package.json
+++ b/microservices/api-index-api/package.json
@@ -15,7 +15,7 @@
     "npm-run-all2": "8.0.4",
     "wait-on": "9.0.3"
   },
-  "packageManager": "pnpm@10.29.1",
+  "packageManager": "pnpm@11.1.2",
   "engines": {
     "node": ">=22.14.0"
   },

--- a/microservices/api-sync-job/package.json
+++ b/microservices/api-sync-job/package.json
@@ -21,7 +21,7 @@
     "wait-on": "9.0.4",
     "wiremock-captain": "4.1.3"
   },
-  "packageManager": "pnpm@10.29.1",
+  "packageManager": "pnpm@11.1.2",
   "engines": {
     "node": ">=22.14.0"
   },

--- a/microservices/api-sync-job/pnpm-workspace.yaml
+++ b/microservices/api-sync-job/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/microservices/quality-gate-api/package.json
+++ b/microservices/quality-gate-api/package.json
@@ -15,7 +15,7 @@
     "npm-run-all2": "8.0.4",
     "wait-on": "9.0.4"
   },
-  "packageManager": "pnpm@10.29.1",
+  "packageManager": "pnpm@11.1.2",
   "engines": {
     "node": ">=22.14.0"
   },

--- a/microservices/report-coordinator-api/package.json
+++ b/microservices/report-coordinator-api/package.json
@@ -15,7 +15,7 @@
     "npm-run-all2": "8.0.4",
     "wait-on": "9.0.4"
   },
-  "packageManager": "pnpm@10.29.1",
+  "packageManager": "pnpm@11.1.2",
   "engines": {
     "node": ">=22.14.0"
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "optionalDependencies": {
     "npm-check-updates": "22.2.0"
   },
-  "packageManager": "pnpm@10.29.1",
+  "packageManager": "pnpm@11.1.2",
   "engines": {
     "node": ">=22.14.0"
   },


### PR DESCRIPTION
> pnpm 11 is here! This release tightens the security defaults introduced throughout the v10 cycle, drops the npm CLI fallback for publishing in favor of a native implementation, replaces the JSON-per-package store index with a single SQLite database, and isolates global installs so they no longer interfere with each other.

[Source](https://pnpm.io/blog/releases/11.0).