### PR TITLE
Fix sonar reliability rating

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@
     <a href="https://bbortt.github.io/snow-white">» Documentation</a>
 </p>
 
+<p align="center">
+  <img alt="GitHub Release" src="https://img.shields.io/github/v/release/bbortt/snow-white">
+  <img alt="GitHub Actions Workflow Status" src="https://img.shields.io/github/actions/workflow/status/bbortt/snow-white/branches.yml">
+  <img alt="Sonar Reliability Rating" src="https://sonarcloud.io/api/project_badges/measure?project=bbortt_snow-white&metric=reliability_rating">
+  <img alt="Sonar Coverage" src="https://img.shields.io/sonar/coverage/bbortt_snow-white?server=https%3A%2F%2Fsonarcloud.io">
+</p>
+
 Snow-White connects your OpenAPI specifications with runtime telemetry data to answer a simple question: **which parts of your API are actually being tested?**
 
 It correlates [OpenTelemetry (OTEL)](https://opentelemetry.io) traces emitted by your application with the endpoints declared in your API specifications - then validates coverage against configurable quality gates.

--- a/microservices/api-gateway/src/main/webapp/app/entities/api-index/api-index.tsx
+++ b/microservices/api-gateway/src/main/webapp/app/entities/api-index/api-index.tsx
@@ -206,9 +206,11 @@ export const ApiIndex = () => {
 
   const getTableHeaderRow = (contentKey: string, defaultHeader: string, fieldName: string): ReactElement => {
     return paginationAndSortingEnabled ? (
-      <th className="hand" onClick={sort(fieldName)}>
-        <Translate contentKey={contentKey}>{defaultHeader}</Translate>
-        <FontAwesomeIcon icon={getSortIconByFieldName(fieldName, paginationState.sort, paginationState.order)} />
+      <th>
+        <button type="button" className="hand border-0 bg-transparent p-0" onClick={sort(fieldName)}>
+          <Translate contentKey={contentKey}>{defaultHeader}</Translate>
+          <FontAwesomeIcon icon={getSortIconByFieldName(fieldName, paginationState.sort, paginationState.order)} />
+        </button>
       </th>
     ) : (
       <th>
@@ -228,10 +230,14 @@ export const ApiIndex = () => {
     return (
       <th>
         <div className="d-flex align-items-center gap-1">
-          <span className="hand d-flex align-items-center gap-1 text-nowrap flex-shrink-0" onClick={sort(fieldName)}>
+          <button
+            type="button"
+            className="hand d-flex align-items-center gap-1 text-nowrap flex-shrink-0 border-0 bg-transparent p-0"
+            onClick={sort(fieldName)}
+          >
             <Translate contentKey={contentKey}>{defaultHeader}</Translate>
             <FontAwesomeIcon icon={getSortIconByFieldName(fieldName, paginationState.sort, paginationState.order)} />
-          </span>
+          </button>
           <AutocompleteInput
             bsSize="sm"
             className="flex-grow-1"

--- a/microservices/api-gateway/src/main/webapp/app/entities/quality-gate-config/quality-gate-config.tsx
+++ b/microservices/api-gateway/src/main/webapp/app/entities/quality-gate-config/quality-gate-config.tsx
@@ -131,20 +131,26 @@ export const QualityGateConfig = () => {
           <Table responsive>
             <thead>
               <tr>
-                <th className="hand" onClick={sort('name')}>
-                  <Translate contentKey="snowWhiteApp.qualityGateConfig.name">Name</Translate>{' '}
-                  <FontAwesomeIcon icon={getSortIconByFieldName('name')} />
+                <th>
+                  <button type="button" className="hand border-0 bg-transparent p-0" onClick={sort('name')}>
+                    <Translate contentKey="snowWhiteApp.qualityGateConfig.name">Name</Translate>{' '}
+                    <FontAwesomeIcon icon={getSortIconByFieldName('name')} />
+                  </button>
                 </th>
                 <th>
                   <Translate contentKey="snowWhiteApp.qualityGateConfig.description">Description</Translate>{' '}
                 </th>
-                <th className="hand" onClick={sort('isPredefined')}>
-                  <Translate contentKey="snowWhiteApp.qualityGateConfig.isPredefined">Is Predefined</Translate>{' '}
-                  <FontAwesomeIcon icon={getSortIconByFieldName('isPredefined')} />
+                <th>
+                  <button type="button" className="hand border-0 bg-transparent p-0" onClick={sort('isPredefined')}>
+                    <Translate contentKey="snowWhiteApp.qualityGateConfig.isPredefined">Is Predefined</Translate>{' '}
+                    <FontAwesomeIcon icon={getSortIconByFieldName('isPredefined')} />
+                  </button>
                 </th>
-                <th className="hand" onClick={sort('minCoveragePercentage')}>
-                  <Translate contentKey="snowWhiteApp.qualityGateConfig.minCoveragePercentage">Required Coverage Percentage</Translate>{' '}
-                  <FontAwesomeIcon icon={getSortIconByFieldName('minCoveragePercentage')} />
+                <th>
+                  <button type="button" className="hand border-0 bg-transparent p-0" onClick={sort('minCoveragePercentage')}>
+                    <Translate contentKey="snowWhiteApp.qualityGateConfig.minCoveragePercentage">Required Coverage Percentage</Translate>{' '}
+                    <FontAwesomeIcon icon={getSortIconByFieldName('minCoveragePercentage')} />
+                  </button>
                 </th>
                 <th />
               </tr>

--- a/microservices/api-gateway/src/main/webapp/app/entities/quality-gate/quality-gate.tsx
+++ b/microservices/api-gateway/src/main/webapp/app/entities/quality-gate/quality-gate.tsx
@@ -112,9 +112,11 @@ export const QualityGate = ({ hidePagination = false }: QualityGateProps) => {
 
   const getTableHeaderRow = (contentKey: string, defaultHeader: string, fieldName: string): ReactElement => {
     return paginationAndSortingEnabled ? (
-      <th className="hand" onClick={sort(fieldName)}>
-        <Translate contentKey={contentKey}>{defaultHeader}</Translate>
-        <FontAwesomeIcon icon={getSortIconByFieldName(fieldName)} />
+      <th>
+        <button type="button" className="hand border-0 bg-transparent p-0" onClick={sort(fieldName)}>
+          <Translate contentKey={contentKey}>{defaultHeader}</Translate>
+          <FontAwesomeIcon icon={getSortIconByFieldName(fieldName)} />
+        </button>
       </th>
     ) : (
       <th>

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,7 @@
           <fileTemplate>
             /org/codehaus/mojo/license/third-party-file-groupByLicense.ftl
           </fileTemplate>
+          <excludedGroups>io.github.bbortt</excludedGroups>
           <excludedScopes>test,provided</excludedScopes>
           <sortArtifactByName>true</sortArtifactByName>
         </configuration>

--- a/toolkit/cli/src/common/glob.spec.ts
+++ b/toolkit/cli/src/common/glob.spec.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Timon Borter <timon.borter@gmx.ch>
+ * Licensed under the Polyform Small Business License 1.0.0
+ * See LICENSE file for full details.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { scanGlob } from './glob';
+
+describe('scanGlob', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'scan-glob-'));
+
+  afterEach(() => {
+    rmSync(tempDir, { force: true, recursive: true });
+  });
+
+  test('returns matches in deterministic lexicographical order', () => {
+    writeFileSync(join(tempDir, 'b.txt'), '');
+    writeFileSync(join(tempDir, 'a.txt'), '');
+    writeFileSync(join(tempDir, 'c.txt'), '');
+
+    expect(scanGlob('*.txt', tempDir)).toEqual(['a.txt', 'b.txt', 'c.txt']);
+  });
+});

--- a/toolkit/cli/src/common/glob.ts
+++ b/toolkit/cli/src/common/glob.ts
@@ -6,5 +6,15 @@
 
 export const scanGlob = (pattern: string, cwd: string): string[] => {
   const glob = new Bun.Glob(pattern);
-  return [...glob.scanSync({ cwd })].sort();
+  return [...glob.scanSync({ cwd })].sort((a, b) => {
+    if (a < b) {
+      return -1;
+    }
+
+    if (a > b) {
+      return 1;
+    }
+
+    return 0;
+  });
 };


### PR DESCRIPTION
Sonar says:

> **Provide a compare function that depends on "String.localeCompare", to reliably sort elements alphabetically.**
"Array.prototype.sort()" and "Array.prototype.toSorted()" should use a compare function [typescript:S2871](https://sonarcloud.io/organizations/bbortt-github/rules?open=typescript%3AS2871&rule_key=typescript%3AS2871)