### PR TITLE
report coordinator api filter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,28 @@
 </p>
 
 <p align="center">
-  <img alt="GitHub Release" src="https://img.shields.io/github/v/release/bbortt/snow-white">
-  <img alt="GitHub Actions Workflow Status" src="https://img.shields.io/github/actions/workflow/status/bbortt/snow-white/branches.yml">
-  <img alt="Sonar Reliability Rating" src="https://sonarcloud.io/api/project_badges/measure?project=bbortt_snow-white&metric=reliability_rating">
-  <img alt="Sonar Coverage" src="https://img.shields.io/sonar/coverage/bbortt_snow-white?server=https%3A%2F%2Fsonarcloud.io">
+  <a href="https://github.com/bbortt/snow-white/releases">
+    <img alt="GitHub Release" src="https://img.shields.io/github/v/release/bbortt/snow-white">
+  </a>
+  <a href="https://github.com/bbortt/snow-white/actions/workflows/branches.yml">
+    <img alt="GitHub Actions Workflow Status" src="https://img.shields.io/github/actions/workflow/status/bbortt/snow-white/branches.yml">
+  </a>
+  <a href="https://sonarcloud.io/project/overview?id=bbortt_snow-white">
+    <img alt="Sonar Reliability Rating" src="https://sonarcloud.io/api/project_badges/measure?project=bbortt_snow-white&metric=reliability_rating">
+  </a>
+  <a href="https://sonarcloud.io/project/overview?id=bbortt_snow-white">
+    <img alt="Sonar Coverage" src="https://img.shields.io/sonar/coverage/bbortt_snow-white?server=https%3A%2F%2Fsonarcloud.io">
+  </a>
 </p>
 
-Snow-White connects your OpenAPI specifications with runtime telemetry data to answer a simple question: **which parts of your API are actually being tested?**
+Snow-White connects your OpenAPI specifications with runtime telemetry data to answer a simple question: **which parts
+of your API are actually being tested?**
 
-It correlates [OpenTelemetry (OTEL)](https://opentelemetry.io) traces emitted by your application with the endpoints declared in your API specifications - then validates coverage against configurable quality gates.
+It correlates [OpenTelemetry (OTEL)](https://opentelemetry.io) traces emitted by your application with the endpoints
+declared in your API specifications - then validates coverage against configurable quality gates.
 
-Snow-White works with **black-box test suites** (system tests, integration tests) as well as **live production traffic**.
+Snow-White works with **black-box test suites** (system tests, integration tests) as well as **live production traffic
+**.
 
 It currently provides insights into:
 
@@ -47,29 +58,34 @@ Full documentation is available at **[bbortt.github.io/snow-white](https://bbort
 ## Installation (for providers)
 
 Snow-White can be installed easily using Helm.
-Detailed instructions and available options are described in ["Deployment"](https://bbortt.github.io/snow-white/deployment).
+Detailed instructions and available options are described
+in ["Deployment"](https://bbortt.github.io/snow-white/deployment).
 
 Individual images could also be used for a custom installation.
 The Docker compose file `dev/docker-compose.yaml` may be used as a starting point.
 
 ## Onboarding (for users)
 
-See ["Onboarding"](https://bbortt.github.io/snow-white/onboarding) for a step-by-step guide to integrating your service with Snow-White.
+See ["Onboarding"](https://bbortt.github.io/snow-white/onboarding) for a step-by-step guide to integrating your service
+with Snow-White.
 
 ## General Concept
 
 Here's a high-level overview of Snow-White.
-For a detailed component and data-flow breakdown, see the [Architecture](https://bbortt.github.io/snow-white/architecture) docs.
+For a detailed component and data-flow breakdown, see
+the [Architecture](https://bbortt.github.io/snow-white/architecture) docs.
 
 1. **Synchronize API Specs** - Snow-White imports OpenAPI specifications from your central interface repository.
 2. **Ingest Telemetry** - It listens to OpenTelemetry tracing data emitted by your applications.
 3. **Correlate & Analyze** - Traces are matched with API operations using service, API name, and version metadata.
 4. **Evaluate Quality Gates** - Results are validated against your configured thresholds.
-5. **Visualize or Export Results** - Coverage and performance insights can be viewed in reports or integrated into CI pipelines.
+5. **Visualize or Export Results** - Coverage and performance insights can be viewed in reports or integrated into CI
+   pipelines.
 
 ### Annotating APIs
 
-The core idea behind Snow-White is that it can only interpret runtime telemetry (e.g. traces) if it knows which API the data belongs to.
+The core idea behind Snow-White is that it can only interpret runtime telemetry (e.g. traces) if it knows which API the
+data belongs to.
 This is achieved by a common annotation model applied both to the specifications and to the telemetry data.
 
 Every API must declare a few key identifiers:
@@ -96,9 +112,11 @@ These annotations are the **linking key** between specifications and runtime tel
 ### Making Specifications Available
 
 Snow-White needs access to the API specifications.
-This is typically done by publishing them to a central HTTP-based service interface repository, where Snow-White can fetch and synchronize them.
+This is typically done by publishing them to a central HTTP-based service interface repository, where Snow-White can
+fetch and synchronize them.
 
-👉 For details, see the [`api-sync-job` documentation](./microservices/api-sync-job) (handles synchronization and version management).
+👉 For details, see the [`api-sync-job` documentation](./microservices/api-sync-job) (handles synchronization and version
+management).
 
 ### Connecting Runtime Data
 
@@ -115,15 +133,18 @@ This enrichment ensures that Snow-White can correlate a runtime span to the corr
 
 To simplify this, the project provides:
 
-- [**OpenAPI Generator Plugin**](./toolkit/openapi-generator) - Generates code that automatically attaches the right annotations.
-- [**Spring Web Autoconfiguration**](./toolkit/spring-web-autoconfiguration) - Automatically enriches spans with API metadata in Spring-based services.
+- [**OpenAPI Generator Plugin**](./toolkit/openapi-generator) - Generates code that automatically attaches the right
+  annotations.
+- [**Spring Web Autoconfiguration**](./toolkit/spring-web-autoconfiguration) - Automatically enriches spans with API
+  metadata in Spring-based services.
 
 ### Coverage Calculation
 
 Once both inputs are in place (specifications + traces), you can trigger a coverage calculation.
 This can be done via the [CLI](./toolkit/cli).
 
-The CLI allows you to synchronize APIs, trigger coverage analysis, and validate results against quality gates directly from your local environment or CI pipeline.
+The CLI allows you to synchronize APIs, trigger coverage analysis, and validate results against quality gates directly
+from your local environment or CI pipeline.
 
 Coverage results are validated against Quality-Gate Configurations.
 These configurations define the rules and thresholds that your API data must satisfy.
@@ -170,10 +191,13 @@ Please be respectful and constructive in all interactions.
 
 ## License
 
-This project is licensed under the [Polyform Small Business License 1.0.0](https://polyformproject.org/licenses/small-business/1.0.0).
+This project is licensed under
+the [Polyform Small Business License 1.0.0](https://polyformproject.org/licenses/small-business/1.0.0).
 
-This means you can freely use, modify, and distribute the software **if your company generates less than $1 million USD in annual revenue** and meets other conditions in the license.
+This means you can freely use, modify, and distribute the software **if your company generates less than $1 million USD
+in annual revenue** and meets other conditions in the license.
 
-If your company exceeds this threshold or you intend to use Snow-White commercially, please reach out for licensing options: [timon.borter@gmx.ch].
+If your company exceeds this threshold or you intend to use Snow-White commercially, please reach out for licensing
+options: [timon.borter@gmx.ch].
 
 See the [LICENSE](./LICENSE) file for full details.

--- a/microservices/report-coordinator-api/src/main/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/api/rest/resource/ReportResource.java
+++ b/microservices/report-coordinator-api/src/main/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/api/rest/resource/ReportResource.java
@@ -82,14 +82,17 @@ public class ReportResource implements ReportApi {
   public ResponseEntity<
     @NonNull List<ListQualityGateReports200ResponseInner>
   > listQualityGateReports(
-    Integer page,
-    Integer size,
-    String sort,
-    String serviceName,
-    String apiName,
-    String apiVersion
+    @Nullable Integer page,
+    @Nullable Integer size,
+    @Nullable String sort,
+    @Nullable String serviceName,
+    @Nullable String apiName,
+    @Nullable String apiVersion
   ) {
     var qualityGateReports = reportService.findAllReports(
+      serviceName,
+      apiName,
+      apiVersion,
       toPageable(page, size, sort)
     );
 

--- a/microservices/report-coordinator-api/src/main/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/api/rest/resource/ReportResource.java
+++ b/microservices/report-coordinator-api/src/main/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/api/rest/resource/ReportResource.java
@@ -81,7 +81,14 @@ public class ReportResource implements ReportApi {
   @Override
   public ResponseEntity<
     @NonNull List<ListQualityGateReports200ResponseInner>
-  > listQualityGateReports(Integer page, Integer size, String sort) {
+  > listQualityGateReports(
+    Integer page,
+    Integer size,
+    String sort,
+    String serviceName,
+    String apiName,
+    String apiVersion
+  ) {
     var qualityGateReports = reportService.findAllReports(
       toPageable(page, size, sort)
     );

--- a/microservices/report-coordinator-api/src/main/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/domain/repository/QualityGateReportRepository.java
+++ b/microservices/report-coordinator-api/src/main/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/domain/repository/QualityGateReportRepository.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,7 +20,9 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface QualityGateReportRepository
-  extends JpaRepository<@NonNull QualityGateReport, @NonNull UUID>
+  extends
+    JpaRepository<@NonNull QualityGateReport, @NonNull UUID>,
+    JpaSpecificationExecutor<@NonNull QualityGateReport>
 {
   @Modifying
   @Query(

--- a/microservices/report-coordinator-api/src/main/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/domain/repository/QualityGateReportSpecification.java
+++ b/microservices/report-coordinator-api/src/main/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/domain/repository/QualityGateReportSpecification.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Timon Borter <timon.borter@gmx.ch>
+ * Licensed under the Polyform Small Business License 1.0.0
+ * See LICENSE file for full details.
+ */
+
+package io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.repository;
+
+import static jakarta.persistence.criteria.JoinType.INNER;
+import static java.util.Objects.nonNull;
+import static lombok.AccessLevel.PRIVATE;
+
+import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.QualityGateReport;
+import jakarta.persistence.criteria.Predicate;
+import java.util.ArrayList;
+import lombok.NoArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.jpa.domain.Specification;
+
+@NoArgsConstructor(access = PRIVATE)
+public final class QualityGateReportSpecification {
+
+  public static Specification<QualityGateReport> from(
+    @Nullable String serviceName,
+    @Nullable String apiName,
+    @Nullable String apiVersion
+  ) {
+    return (root, query, criteriaBuilder) -> {
+      if (serviceName == null && apiName == null && apiVersion == null) {
+        return criteriaBuilder.conjunction();
+      }
+
+      query.distinct(true);
+      var apiTests = root.join("apiTests", INNER);
+
+      var predicates = new ArrayList<Predicate>();
+      if (nonNull(serviceName)) {
+        predicates.add(
+          criteriaBuilder.equal(apiTests.get("serviceName"), serviceName)
+        );
+      }
+      if (nonNull(apiName)) {
+        predicates.add(criteriaBuilder.equal(apiTests.get("apiName"), apiName));
+      }
+      if (nonNull(apiVersion)) {
+        predicates.add(
+          criteriaBuilder.equal(apiTests.get("apiVersion"), apiVersion)
+        );
+      }
+
+      return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+    };
+  }
+}

--- a/microservices/report-coordinator-api/src/main/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/service/ReportService.java
+++ b/microservices/report-coordinator-api/src/main/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/service/ReportService.java
@@ -22,6 +22,7 @@ import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.m
 import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportParameter;
 import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.repository.ApiTestRepository;
 import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.repository.QualityGateReportRepository;
+import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.repository.QualityGateReportSpecification;
 import io.github.bbortt.snow.white.microservices.report.coordinator.api.service.exception.QualityGateNotFoundException;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
@@ -31,6 +32,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -233,7 +235,15 @@ public class ReportService {
   }
 
   @WithSpan
-  public Page<@NonNull QualityGateReport> findAllReports(Pageable pageable) {
-    return qualityGateReportRepository.findAll(pageable);
+  public Page<@NonNull QualityGateReport> findAllReports(
+    @Nullable String serviceName,
+    @Nullable String apiName,
+    @Nullable String apiVersion,
+    Pageable pageable
+  ) {
+    return qualityGateReportRepository.findAll(
+      QualityGateReportSpecification.from(serviceName, apiName, apiVersion),
+      pageable
+    );
   }
 }

--- a/microservices/report-coordinator-api/src/main/resources/openapi/v1-report-api.yml
+++ b/microservices/report-coordinator-api/src/main/resources/openapi/v1-report-api.yml
@@ -35,6 +35,27 @@ paths:
           schema:
             type: string
             example: initiatedAt,desc
+        - name: serviceName
+          in: query
+          required: false
+          schema:
+            type: string
+            maxLength: 64
+          description: 'Filter results to reports including APIs belonging to this service name (combine with apiName for cascading)'
+        - name: apiName
+          in: query
+          required: false
+          schema:
+            type: string
+            maxLength: 64
+          description: 'Filter results to reports including APIs with this API name (combine with serviceName for cascading)'
+        - name: apiVersion
+          in: query
+          required: false
+          schema:
+            type: string
+            maxLength: 16
+          description: 'Filter results to reports including APIs with this API version'
       responses:
         '200':
           description: 'Paginated list of Quality-Gate Reports'

--- a/microservices/report-coordinator-api/src/test/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/api/rest/resource/ReportResourceIT.java
+++ b/microservices/report-coordinator-api/src/test/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/api/rest/resource/ReportResourceIT.java
@@ -9,13 +9,8 @@ package io.github.bbortt.snow.white.microservices.report.coordinator.api.api.res
 import static io.github.bbortt.snow.white.commons.quality.gate.ApiType.UNSPECIFIED;
 import static io.github.bbortt.snow.white.commons.quality.gate.OpenApiCoverageCriteria.PATH_COVERAGE;
 import static io.github.bbortt.snow.white.commons.web.PaginationUtils.HEADER_X_TOTAL_COUNT;
-import static io.github.bbortt.snow.white.microservices.report.coordinator.api.api.rest.ReportApi.PATH_GET_REPORT_BY_CALCULATION_ID;
-import static io.github.bbortt.snow.white.microservices.report.coordinator.api.api.rest.ReportApi.PATH_GET_REPORT_BY_CALCULATION_ID_AS_J_UNIT;
-import static io.github.bbortt.snow.white.microservices.report.coordinator.api.api.rest.ReportApi.PATH_LIST_QUALITY_GATE_REPORTS;
-import static io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportStatus.FAILED;
-import static io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportStatus.IN_PROGRESS;
-import static io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportStatus.NOT_STARTED;
-import static io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportStatus.PASSED;
+import static io.github.bbortt.snow.white.microservices.report.coordinator.api.api.rest.ReportApi.*;
+import static io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportStatus.*;
 import static java.lang.Boolean.TRUE;
 import static java.math.BigDecimal.ONE;
 import static java.math.RoundingMode.HALF_UP;
@@ -30,18 +25,12 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.util.StreamUtils.copyToString;
 
 import io.github.bbortt.snow.white.microservices.report.coordinator.api.AbstractReportCoordinationServiceIT;
 import io.github.bbortt.snow.white.microservices.report.coordinator.api.api.rest.dto.ListQualityGateReports200ResponseInner;
-import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ApiTest;
-import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ApiTestResult;
-import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.QualityGateReport;
-import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportParameter;
-import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ReportStatus;
+import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.*;
 import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.repository.ApiTestRepository;
 import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.repository.QualityGateReportRepository;
 import java.math.BigDecimal;
@@ -430,6 +419,239 @@ class ReportResourceIT extends AbstractReportCoordinationServiceIT {
     );
 
     return persistedQualityGateReport.withApiTests(Set.of(persistedApiTests));
+  }
+
+  @Test
+  void findAllReports_filteredByServiceName_returnsOnlyMatchingReports()
+    throws Exception {
+    var calculationId1 = UUID.fromString(
+      "30f7b64c-2a31-4452-90bc-1210d4a2faab"
+    );
+    createAndPersistQualityGateReport(
+      calculationId1,
+      "alpha",
+      "api1",
+      "v1",
+      "1h",
+      PASSED
+    );
+
+    var calculationId2 = UUID.fromString(
+      "84753ea3-3ee3-446b-be96-edb6b049f4a3"
+    );
+    createAndPersistQualityGateReport(
+      calculationId2,
+      "beta",
+      "api1",
+      "v1",
+      "1h",
+      PASSED
+    );
+
+    mockMvc
+      .perform(
+        get(PATH_LIST_QUALITY_GATE_REPORTS).queryParam("serviceName", "alpha")
+      )
+      .andExpect(status().isOk())
+      .andExpect(header().string(HEADER_X_TOTAL_COUNT, "1"))
+      .andExpect(jsonPath("$.length()").value(1))
+      .andExpect(
+        jsonPath("$[0].calculationId").value(calculationId1.toString())
+      );
+  }
+
+  @Test
+  void findAllReports_filteredByApiName_returnsOnlyMatchingReports()
+    throws Exception {
+    var calculationId1 = UUID.fromString(
+      "a785a394-c1ef-492d-b96c-fa6a24ff7e10"
+    );
+    createAndPersistQualityGateReport(
+      calculationId1,
+      "svc",
+      "foo-api",
+      "v1",
+      "1h",
+      PASSED
+    );
+
+    var calculationId2 = UUID.fromString(
+      "65fef062-2dfe-47b6-9182-79ede0d37a6f"
+    );
+    createAndPersistQualityGateReport(
+      calculationId2,
+      "svc",
+      "bar-api",
+      "v1",
+      "1h",
+      PASSED
+    );
+
+    mockMvc
+      .perform(
+        get(PATH_LIST_QUALITY_GATE_REPORTS).queryParam("apiName", "foo-api")
+      )
+      .andExpect(status().isOk())
+      .andExpect(header().string(HEADER_X_TOTAL_COUNT, "1"))
+      .andExpect(jsonPath("$.length()").value(1))
+      .andExpect(
+        jsonPath("$[0].calculationId").value(calculationId1.toString())
+      );
+  }
+
+  @Test
+  void findAllReports_filteredByApiVersion_returnsOnlyMatchingReports()
+    throws Exception {
+    var calculationId1 = UUID.fromString(
+      "8f75c75e-c4a2-4a36-af55-70c98565b098"
+    );
+    createAndPersistQualityGateReport(
+      calculationId1,
+      "svc",
+      "api1",
+      "v1",
+      "1h",
+      PASSED
+    );
+
+    var calculationId2 = UUID.fromString(
+      "2a4bb6c5-ee0b-4f8d-a3ce-ac5abc24f2be"
+    );
+    createAndPersistQualityGateReport(
+      calculationId2,
+      "svc",
+      "api1",
+      "v2",
+      "1h",
+      PASSED
+    );
+
+    mockMvc
+      .perform(
+        get(PATH_LIST_QUALITY_GATE_REPORTS).queryParam("apiVersion", "v1")
+      )
+      .andExpect(status().isOk())
+      .andExpect(header().string(HEADER_X_TOTAL_COUNT, "1"))
+      .andExpect(jsonPath("$.length()").value(1))
+      .andExpect(
+        jsonPath("$[0].calculationId").value(calculationId1.toString())
+      );
+  }
+
+  @Test
+  void findAllReports_filteredByServiceNameAndApiName_returnsOnlyMatchingReports()
+    throws Exception {
+    var calculationId1 = UUID.fromString(
+      "2e2bafb5-c0cd-435c-8cb9-b91516c7ef3d"
+    );
+    createAndPersistQualityGateReport(
+      calculationId1,
+      "alpha",
+      "foo-api",
+      "v1",
+      "1h",
+      PASSED
+    );
+
+    var calculationId2 = UUID.fromString(
+      "3f1ba337-3bf5-46af-89a3-8ddcf199caa7"
+    );
+    createAndPersistQualityGateReport(
+      calculationId2,
+      "alpha",
+      "bar-api",
+      "v1",
+      "1h",
+      PASSED
+    );
+
+    mockMvc
+      .perform(
+        get(PATH_LIST_QUALITY_GATE_REPORTS)
+          .queryParam("serviceName", "alpha")
+          .queryParam("apiName", "foo-api")
+      )
+      .andExpect(status().isOk())
+      .andExpect(header().string(HEADER_X_TOTAL_COUNT, "1"))
+      .andExpect(jsonPath("$.length()").value(1))
+      .andExpect(
+        jsonPath("$[0].calculationId").value(calculationId1.toString())
+      );
+  }
+
+  @Test
+  void findAllReports_withNonMatchingFilter_returnsEmptyList()
+    throws Exception {
+    var calculationId1 = UUID.fromString(
+      "1eddb17f-60b6-4b8a-8a9f-d547e6204f27"
+    );
+    createAndPersistQualityGateReport(
+      calculationId1,
+      "alpha",
+      "api1",
+      "v1",
+      "1h",
+      PASSED
+    );
+
+    mockMvc
+      .perform(
+        get(PATH_LIST_QUALITY_GATE_REPORTS).queryParam(
+          "serviceName",
+          "nonexistent"
+        )
+      )
+      .andExpect(status().isOk())
+      .andExpect(header().string(HEADER_X_TOTAL_COUNT, "0"))
+      .andExpect(jsonPath("$.length()").value(0));
+  }
+
+  @Test
+  void findAllReports_withFilter_respectsPagination() throws Exception {
+    var calculationId1 = UUID.fromString(
+      "bc4600b8-abb4-4775-b650-b2139ffacc35"
+    );
+    createAndPersistQualityGateReport(
+      calculationId1,
+      "alpha",
+      "api1",
+      "v1",
+      "1h",
+      PASSED
+    );
+    var calculationId2 = UUID.fromString(
+      "5aa1c1ea-bd4d-4d9c-a401-d29e6da06d05"
+    );
+    createAndPersistQualityGateReport(
+      calculationId2,
+      "alpha",
+      "api2",
+      "v1",
+      "1h",
+      PASSED
+    );
+    var calculationId3 = UUID.fromString(
+      "36c06802-7be1-4ad4-800d-3e7595945e28"
+    );
+    createAndPersistQualityGateReport(
+      calculationId3,
+      "alpha",
+      "api3",
+      "v1",
+      "1h",
+      PASSED
+    );
+
+    mockMvc
+      .perform(
+        get(PATH_LIST_QUALITY_GATE_REPORTS)
+          .queryParam("serviceName", "alpha")
+          .queryParam("size", "2")
+          .queryParam("page", "0")
+      )
+      .andExpect(status().isOk())
+      .andExpect(header().string(HEADER_X_TOTAL_COUNT, "3"))
+      .andExpect(jsonPath("$.length()").value(2));
   }
 
   private void createSimpleApiTestSet(QualityGateReport qualityGateReport) {

--- a/microservices/report-coordinator-api/src/test/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/api/rest/resource/ReportResourceUnitTest.java
+++ b/microservices/report-coordinator-api/src/test/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/api/rest/resource/ReportResourceUnitTest.java
@@ -14,8 +14,12 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.mockito.ArgumentCaptor.captor;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
@@ -273,7 +277,12 @@ class ReportResourceUnitTest {
       ArgumentCaptor<Pageable> pageableArgumentCaptor = captor();
       doReturn(qualityGateReportsPage)
         .when(reportServiceMock)
-        .findAllReports(pageableArgumentCaptor.capture());
+        .findAllReports(
+          isNull(),
+          isNull(),
+          isNull(),
+          pageableArgumentCaptor.capture()
+        );
 
       doReturn(Stream.of(report1, report2))
         .when(qualityGateReportsPage)
@@ -331,7 +340,12 @@ class ReportResourceUnitTest {
       ArgumentCaptor<Pageable> pageableArgumentCaptor = captor();
       doReturn(qualityGateReportsPage)
         .when(reportServiceMock)
-        .findAllReports(pageableArgumentCaptor.capture());
+        .findAllReports(
+          isNull(),
+          isNull(),
+          isNull(),
+          pageableArgumentCaptor.capture()
+        );
 
       doReturn(Stream.empty()).when(qualityGateReportsPage).stream();
 
@@ -370,6 +384,38 @@ class ReportResourceUnitTest {
               Sort.by(Sort.Direction.DESC, "createdAt")
             )
         );
+    }
+
+    @Test
+    void shouldPassFiltersToService_whenFiltersProvided() {
+      Page<@NonNull QualityGateReport> qualityGateReportsPage = mock();
+      doReturn(0L).when(qualityGateReportsPage).getTotalElements();
+      doReturn(Stream.empty()).when(qualityGateReportsPage).stream();
+
+      doReturn(qualityGateReportsPage)
+        .when(reportServiceMock)
+        .findAllReports(
+          eq("my-service"),
+          eq("my-api"),
+          eq("v1"),
+          any(Pageable.class)
+        );
+
+      fixture.listQualityGateReports(
+        0,
+        10,
+        "createdAt,asc",
+        "my-service",
+        "my-api",
+        "v1"
+      );
+
+      verify(reportServiceMock).findAllReports(
+        eq("my-service"),
+        eq("my-api"),
+        eq("v1"),
+        any(Pageable.class)
+      );
     }
   }
 }

--- a/microservices/report-coordinator-api/src/test/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/api/rest/resource/ReportResourceUnitTest.java
+++ b/microservices/report-coordinator-api/src/test/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/api/rest/resource/ReportResourceUnitTest.java
@@ -287,7 +287,14 @@ class ReportResourceUnitTest {
 
       ResponseEntity<
         @NonNull List<ListQualityGateReports200ResponseInner>
-      > response = fixture.listQualityGateReports(page, size, sort);
+      > response = fixture.listQualityGateReports(
+        page,
+        size,
+        sort,
+        null,
+        null,
+        null
+      );
 
       assertThat(response)
         .isNotNull()
@@ -330,7 +337,14 @@ class ReportResourceUnitTest {
 
       ResponseEntity<
         @NonNull List<ListQualityGateReports200ResponseInner>
-      > response = fixture.listQualityGateReports(page, size, sort);
+      > response = fixture.listQualityGateReports(
+        page,
+        size,
+        sort,
+        null,
+        null,
+        null
+      );
 
       verifyNoInteractions(qualityGateReportMapperMock);
 

--- a/microservices/report-coordinator-api/src/test/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/domain/repository/QualityGateReportSpecificationUnitTest.java
+++ b/microservices/report-coordinator-api/src/test/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/domain/repository/QualityGateReportSpecificationUnitTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026 Timon Borter <timon.borter@gmx.ch>
+ * Licensed under the Polyform Small Business License 1.0.0
+ * See LICENSE file for full details.
+ */
+
+package io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.repository;
+
+import static jakarta.persistence.criteria.JoinType.INNER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.ApiTest;
+import io.github.bbortt.snow.white.microservices.report.coordinator.api.domain.model.QualityGateReport;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith({ MockitoExtension.class })
+class QualityGateReportSpecificationUnitTest {
+
+  @Mock
+  private Root<QualityGateReport> rootMock;
+
+  @Mock
+  private CriteriaQuery<?> criteriaQueryMock;
+
+  @Mock
+  private CriteriaBuilder criteriaBuilderMock;
+
+  @Nested
+  class FromTest {
+
+    @Test
+    void shouldReturnConjunction_whenAllFiltersAreNull() {
+      var conjunction = mock(Predicate.class);
+      doReturn(conjunction).when(criteriaBuilderMock).conjunction();
+
+      var result = QualityGateReportSpecification.from(
+        null,
+        null,
+        null
+      ).toPredicate(rootMock, criteriaQueryMock, criteriaBuilderMock);
+
+      assertThat(result).isSameAs(conjunction);
+      verifyNoInteractions(rootMock);
+      verify(criteriaQueryMock, never()).distinct(true);
+    }
+
+    @Test
+    void shouldJoinAndFilterByServiceName_whenOnlyServiceNameIsProvided() {
+      Join<QualityGateReport, ApiTest> joinMock = mock();
+      doReturn(joinMock).when(rootMock).join("apiTests", INNER);
+
+      Path<String> serviceNamePath = mock();
+      doReturn(serviceNamePath).when(joinMock).get("serviceName");
+
+      var predicate = mock(Predicate.class);
+      doReturn(predicate)
+        .when(criteriaBuilderMock)
+        .equal(serviceNamePath, "my-service");
+      doReturn(predicate).when(criteriaBuilderMock).and(predicate);
+
+      QualityGateReportSpecification.from("my-service", null, null).toPredicate(
+        rootMock,
+        criteriaQueryMock,
+        criteriaBuilderMock
+      );
+
+      verify(criteriaQueryMock).distinct(true);
+      verify(rootMock).join("apiTests", INNER);
+      verify(criteriaBuilderMock).equal(serviceNamePath, "my-service");
+      verify(joinMock, never()).get("apiName");
+      verify(joinMock, never()).get("apiVersion");
+    }
+
+    @Test
+    void shouldJoinAndFilterByApiName_whenOnlyApiNameIsProvided() {
+      Join<QualityGateReport, ApiTest> joinMock = mock();
+      doReturn(joinMock).when(rootMock).join("apiTests", INNER);
+
+      Path<String> apiNamePath = mock();
+      doReturn(apiNamePath).when(joinMock).get("apiName");
+
+      var predicate = mock(Predicate.class);
+      doReturn(predicate)
+        .when(criteriaBuilderMock)
+        .equal(apiNamePath, "my-api");
+      doReturn(predicate).when(criteriaBuilderMock).and(predicate);
+
+      QualityGateReportSpecification.from(null, "my-api", null).toPredicate(
+        rootMock,
+        criteriaQueryMock,
+        criteriaBuilderMock
+      );
+
+      verify(criteriaQueryMock).distinct(true);
+      verify(criteriaBuilderMock).equal(apiNamePath, "my-api");
+      verify(joinMock, never()).get("serviceName");
+      verify(joinMock, never()).get("apiVersion");
+    }
+
+    @Test
+    void shouldJoinAndFilterByApiVersion_whenOnlyApiVersionIsProvided() {
+      Join<QualityGateReport, ApiTest> joinMock = mock();
+      doReturn(joinMock).when(rootMock).join("apiTests", INNER);
+
+      Path<String> apiVersionPath = mock();
+      doReturn(apiVersionPath).when(joinMock).get("apiVersion");
+
+      var predicate = mock(Predicate.class);
+      doReturn(predicate).when(criteriaBuilderMock).equal(apiVersionPath, "v1");
+      doReturn(predicate).when(criteriaBuilderMock).and(predicate);
+
+      QualityGateReportSpecification.from(null, null, "v1").toPredicate(
+        rootMock,
+        criteriaQueryMock,
+        criteriaBuilderMock
+      );
+
+      verify(criteriaQueryMock).distinct(true);
+      verify(criteriaBuilderMock).equal(apiVersionPath, "v1");
+      verify(joinMock, never()).get("serviceName");
+      verify(joinMock, never()).get("apiName");
+    }
+
+    @Test
+    void shouldJoinOnceAndApplyAllPredicates_whenAllFiltersAreProvided() {
+      Join<QualityGateReport, ApiTest> joinMock = mock();
+      doReturn(joinMock).when(rootMock).join("apiTests", INNER);
+
+      Path<String> serviceNamePath = mock();
+      doReturn(serviceNamePath).when(joinMock).get("serviceName");
+      Path<String> apiNamePath = mock();
+      doReturn(apiNamePath).when(joinMock).get("apiName");
+      Path<String> apiVersionPath = mock();
+      doReturn(apiVersionPath).when(joinMock).get("apiVersion");
+
+      var p1 = mock(Predicate.class);
+      doReturn(p1).when(criteriaBuilderMock).equal(serviceNamePath, "svc");
+      var p2 = mock(Predicate.class);
+      doReturn(p2).when(criteriaBuilderMock).equal(apiNamePath, "api");
+      var p3 = mock(Predicate.class);
+      doReturn(p3).when(criteriaBuilderMock).equal(apiVersionPath, "v1");
+
+      QualityGateReportSpecification.from("svc", "api", "v1").toPredicate(
+        rootMock,
+        criteriaQueryMock,
+        criteriaBuilderMock
+      );
+
+      verify(criteriaQueryMock).distinct(true);
+      verify(rootMock).join("apiTests", INNER);
+      verify(criteriaBuilderMock).and(p1, p2, p3);
+    }
+  }
+}

--- a/microservices/report-coordinator-api/src/test/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/service/ReportServiceUnitTest.java
+++ b/microservices/report-coordinator-api/src/test/java/io/github/bbortt/snow/white/microservices/report/coordinator/api/service/ReportServiceUnitTest.java
@@ -16,13 +16,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentCaptor.captor;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 import io.github.bbortt.snow.white.commons.event.OpenApiCoverageResponseEvent;
 import io.github.bbortt.snow.white.commons.event.dto.ApiInformation;
@@ -51,6 +46,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 @ExtendWith({ MockitoExtension.class })
 class ReportServiceUnitTest {
@@ -453,17 +449,45 @@ class ReportServiceUnitTest {
   class FindAllReportsTest {
 
     @Test
-    void shouldDelegateToRepository() {
+    void shouldDelegateToRepository_withNoFilters() {
       var pageable = Pageable.unpaged();
-      var page = Page.empty();
+      Page<QualityGateReport> page = Page.empty();
 
-      doReturn(page).when(qualityGateReportRepositoryMock).findAll(pageable);
+      doReturn(page)
+        .when(qualityGateReportRepositoryMock)
+        .findAll(any(Specification.class), eq(pageable));
 
       Page<@NonNull QualityGateReport> result = fixture.findAllReports(
+        null,
+        null,
+        null,
         pageable
       );
 
       assertThat(result).isEqualTo(page);
+    }
+
+    @Test
+    void shouldDelegateToRepository_withFilters() {
+      var pageable = Pageable.unpaged();
+      Page<QualityGateReport> page = Page.empty();
+
+      doReturn(page)
+        .when(qualityGateReportRepositoryMock)
+        .findAll(any(Specification.class), eq(pageable));
+
+      Page<@NonNull QualityGateReport> result = fixture.findAllReports(
+        "my-service",
+        "my-api",
+        "v1",
+        pageable
+      );
+
+      assertThat(result).isEqualTo(page);
+      verify(qualityGateReportRepositoryMock).findAll(
+        any(Specification.class),
+        eq(pageable)
+      );
     }
   }
 }


### PR DESCRIPTION
 enhancing endpoint `/api/rest/v1/reports` with filtering options:

```yaml
 - name: serviceName
    description: 'Filter results to reports including APIs belonging to this service name (combine with apiName for cascading)'
  - name: apiName
    description: 'Filter results to reports including APIs with this API name (combine with serviceName for cascading)'
  - name: apiVersion
    description: 'Filter results to reports including APIs with this API version'
```