### PR TITLE
match operation.id attribute first

### DIFF
--- a/examples/example-spring-boot/src/main/java/io/github/bbortt/snow/white/example/application/api/PingPongApi.java
+++ b/examples/example-spring-boot/src/main/java/io/github/bbortt/snow/white/example/application/api/PingPongApi.java
@@ -32,6 +32,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @Tag(name = "ping-pong", description = "Ping-pong operations")
+@SnowWhiteInformation(
+  serviceName = "example-spring-boot",
+  apiName = "ping-pong",
+  apiVersion = "1.0.0"
+)
 public class PingPongApi {
 
   @GetMapping("/ping")
@@ -57,12 +62,7 @@ public class PingPongApi {
       content = @Content(schema = @Schema(implementation = ErrorResponse.class))
     ),
   })
-  @SnowWhiteInformation(
-    serviceName = "example-spring-boot",
-    apiName = "ping-pong",
-    apiVersion = "1.0.0",
-    operationId = "getPing"
-  )
+  @SnowWhiteInformation(operationId = "getPing")
   public ResponseEntity<PongResponse> getPing(
     @Parameter(
       description = "Optional message to include with the ping"
@@ -102,12 +102,7 @@ public class PingPongApi {
       content = @Content(schema = @Schema(implementation = ErrorResponse.class))
     ),
   })
-  @SnowWhiteInformation(
-    serviceName = "example-spring-boot",
-    apiName = "ping-pong",
-    apiVersion = "1.0.0",
-    operationId = "postPong"
-  )
+  @SnowWhiteInformation(operationId = "postPong")
   public ResponseEntity<SuccessResponse> postPong(
     @Valid @RequestBody PingRequest pingRequest
   ) {
@@ -144,12 +139,7 @@ public class PingPongApi {
       content = @Content(schema = @Schema(implementation = ErrorResponse.class))
     ),
   })
-  @SnowWhiteInformation(
-    serviceName = "example-spring-boot",
-    apiName = "ping-pong",
-    apiVersion = "1.0.0",
-    operationId = "getPung"
-  )
+  @SnowWhiteInformation(operationId = "getPung")
   public ResponseEntity<SuccessResponse> getPung(
     @Parameter(
       description = "Message to include with the ping",

--- a/internal/commons/pom.xml
+++ b/internal/commons/pom.xml
@@ -21,10 +21,6 @@
   <artifactId>commons</artifactId>
   <packaging>jar</packaging>
 
-  <properties>
-    <mockito.version>5.23.0</mockito.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
@@ -107,12 +103,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/config/OpenApiCoverageStreamProperties.java
+++ b/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/config/OpenApiCoverageStreamProperties.java
@@ -28,6 +28,8 @@ public class OpenApiCoverageStreamProperties {
 
   private Boolean initTopics = false;
 
+  private String operationIdAttribute = "openapi.operation.id";
+
   private final ApiIndexProperties apiIndex = new ApiIndexProperties();
   private final FilteringProperties filtering = new FilteringProperties();
 

--- a/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/OpenApiCoverageService.java
+++ b/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/OpenApiCoverageService.java
@@ -20,8 +20,10 @@ import static java.util.Collections.emptySet;
 import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.groupingBy;
 import static org.springframework.util.CollectionUtils.isEmpty;
+import static org.springframework.util.StringUtils.hasText;
 
 import io.github.bbortt.snow.white.commons.event.dto.OpenApiTestResult;
+import io.github.bbortt.snow.white.microservices.openapi.coverage.stream.config.OpenApiCoverageStreamProperties;
 import io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.dto.OpenApiTestContext;
 import io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.dto.OpenTelemetryData;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
@@ -53,6 +55,7 @@ public class OpenApiCoverageService {
     new PathItemMapping(PathItem::getOptions, OPTIONS)
   );
 
+  private final OpenApiCoverageStreamProperties openApiCoverageStreamProperties;
   private final OpenApiCoverageCalculationCoordinator openApiCoverageCalculationCoordinator;
 
   @WithSpan
@@ -78,58 +81,111 @@ public class OpenApiCoverageService {
       openTelemetryData.size()
     );
 
-    var pathToOpenAPIOperationMap = extractPathsAndOperations(openApi);
-    var pathToTelemetryMap = groupTelemetryByPath(openTelemetryData);
+    var pathIndex = buildPathIndex(openApi);
+    var pathToTelemetryMap = groupTelemetryByPath(
+      openTelemetryData,
+      pathIndex.operationIdToOperationKey()
+    );
 
     return openApiCoverageCalculationCoordinator.calculate(
-      pathToOpenAPIOperationMap,
+      pathIndex.operationKeyToOperation(),
       pathToTelemetryMap
     );
   }
 
-  private Map<String, Operation> extractPathsAndOperations(OpenAPI openApi) {
-    Map<String, Operation> pathToOpenAPIOperationMap = new HashMap<>();
+  private OpenApiPathIndex buildPathIndex(OpenAPI openApi) {
+    Map<String, Operation> operationKeyToOperation = new HashMap<>();
+    Map<String, String> operationIdToOperationKey = new HashMap<>();
 
     if (isEmpty(openApi.getPaths())) {
-      return pathToOpenAPIOperationMap;
+      return new OpenApiPathIndex(
+        operationKeyToOperation,
+        operationIdToOperationKey
+      );
     }
 
     openApi.getPaths().forEach((path, pathItem) -> {
       for (var pathItemMapping : METHOD_ACCESSORS) {
         var operation = pathItemMapping.mappingFunction().apply(pathItem);
         if (nonNull(operation)) {
-          pathToOpenAPIOperationMap.put(
-            toOperationKey(path, pathItemMapping.httpMethodString()),
-            operation
+          var operationKey = toOperationKey(
+            path,
+            pathItemMapping.httpMethodString()
           );
+          operationKeyToOperation.put(operationKey, operation);
+          if (hasText(operation.getOperationId())) {
+            operationIdToOperationKey.put(
+              operation.getOperationId(),
+              operationKey
+            );
+          }
         }
       }
     });
 
-    return pathToOpenAPIOperationMap;
+    return new OpenApiPathIndex(
+      operationKeyToOperation,
+      operationIdToOperationKey
+    );
   }
 
   private Map<String, List<OpenTelemetryData>> groupTelemetryByPath(
-    Set<OpenTelemetryData> telemetryData
+    Set<OpenTelemetryData> telemetryData,
+    Map<String, String> operationIdToOperationKey
   ) {
+    var operationIdAttr =
+      openApiCoverageStreamProperties.getOperationIdAttribute();
     return telemetryData
       .stream()
-      .filter(
-        data ->
-          // TODO: This should also take request/response into account!
-          data.attributes().has(HTTP_REQUEST_METHOD.getKey()) &&
-          data.attributes().has(URL_PATH.getKey())
+      .filter(data ->
+        isRoutable(data, operationIdAttr, operationIdToOperationKey)
       )
       .collect(
-        groupingBy(data -> {
-          String method = data
-            .attributes()
-            .get(HTTP_REQUEST_METHOD.getKey())
-            .asString();
-          String path = data.attributes().get(URL_PATH.getKey()).asString();
-          return toOperationKey(path, method);
-        })
+        groupingBy(data ->
+          resolveOperationKey(data, operationIdAttr, operationIdToOperationKey)
+        )
       );
+  }
+
+  private boolean isRoutable(
+    OpenTelemetryData data,
+    String operationIdAttr,
+    Map<String, String> operationIdToOperationKey
+  ) {
+    if (data.attributes().has(operationIdAttr)) {
+      var operationId = data.attributes().get(operationIdAttr).asString();
+      if (
+        hasText(operationId) &&
+        operationIdToOperationKey.containsKey(operationId)
+      ) {
+        return true;
+      }
+    }
+    // TODO: This should also take request/response into account!
+    return (
+      data.attributes().has(HTTP_REQUEST_METHOD.getKey()) &&
+      data.attributes().has(URL_PATH.getKey())
+    );
+  }
+
+  private String resolveOperationKey(
+    OpenTelemetryData data,
+    String operationIdAttr,
+    Map<String, String> operationIdToOperationKey
+  ) {
+    if (data.attributes().has(operationIdAttr)) {
+      var operationId = data.attributes().get(operationIdAttr).asString();
+      if (hasText(operationId)) {
+        var resolvedKey = operationIdToOperationKey.get(operationId);
+        if (nonNull(resolvedKey)) {
+          return resolvedKey;
+        }
+      }
+    }
+    return toOperationKey(
+      data.attributes().get(URL_PATH.getKey()).asString(),
+      data.attributes().get(HTTP_REQUEST_METHOD.getKey()).asString()
+    );
   }
 
   private record PathItemMapping(
@@ -140,4 +196,9 @@ public class OpenApiCoverageService {
       return httpMethod.name();
     }
   }
+
+  private record OpenApiPathIndex(
+    Map<String, Operation> operationKeyToOperation,
+    Map<String, String> operationIdToOperationKey
+  ) {}
 }

--- a/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/OpenApiCoverageService.java
+++ b/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/OpenApiCoverageService.java
@@ -182,6 +182,7 @@ public class OpenApiCoverageService {
         }
       }
     }
+
     return toOperationKey(
       data.attributes().get(URL_PATH.getKey()).asString(),
       data.attributes().get(HTTP_REQUEST_METHOD.getKey()).asString()

--- a/microservices/openapi-coverage-stream/src/test/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/OpenApiCoverageServiceUnitTest.java
+++ b/microservices/openapi-coverage-stream/src/test/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/OpenApiCoverageServiceUnitTest.java
@@ -18,11 +18,13 @@ import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentCaptor.captor;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import io.github.bbortt.snow.white.commons.event.dto.OpenApiTestResult;
+import io.github.bbortt.snow.white.microservices.openapi.coverage.stream.config.OpenApiCoverageStreamProperties;
 import io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.dto.OpenApiTestContext;
 import io.github.bbortt.snow.white.microservices.openapi.coverage.stream.service.dto.OpenTelemetryData;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -36,6 +38,7 @@ import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -56,6 +59,7 @@ class OpenApiCoverageServiceUnitTest {
   @BeforeEach
   void beforeEachSetup() {
     fixture = new OpenApiCoverageService(
+      new OpenApiCoverageStreamProperties(),
       openApiCoverageCalculationCoordinatorMock
     );
   }
@@ -178,6 +182,114 @@ class OpenApiCoverageServiceUnitTest {
 
       verifyNoInteractions(openAPIMock);
       verifyNoInteractions(openApiCoverageCalculationCoordinatorMock);
+    }
+  }
+
+  @Nested
+  class TestOperationIdFastPath {
+
+    private static final String LOOKBACK_WINDOW = "lookbackWindow";
+
+    @Mock
+    private OpenAPI openAPIMock;
+
+    private OpenApiTestContext openApiTestContext;
+
+    @BeforeEach
+    void beforeEachSetup() {
+      openApiTestContext = new OpenApiTestContext(
+        defaultApiInformation(),
+        openAPIMock,
+        LOOKBACK_WINDOW,
+        null
+      );
+    }
+
+    @Test
+    void shouldGroupTelemetryByTemplateKey_whenOperationIdIsKnown() {
+      var attributes = JsonMapper.shared().readTree(
+        // language=json
+        """
+        {"openapi.operation.id":"getPung","http.request.method":"GET","url.path":"/pung/hello"}
+        """
+      );
+      openApiTestContext = openApiTestContext.withOpenTelemetryData(
+        Set.of(new OpenTelemetryData("spanId", "traceId", attributes))
+      );
+
+      var operation = mock(Operation.class);
+      doReturn("getPung").when(operation).getOperationId();
+      var paths = new Paths();
+      paths.addPathItem("/pung/{message}", new PathItem().get(operation));
+      doReturn(paths).when(openAPIMock).getPaths();
+
+      ArgumentCaptor<Map<String, List<OpenTelemetryData>>> telemetryCaptor =
+        captor();
+      doReturn(emptySet())
+        .when(openApiCoverageCalculationCoordinatorMock)
+        .calculate(any(), telemetryCaptor.capture());
+
+      fixture.calculateCoverage(openApiTestContext);
+
+      assertThat(telemetryCaptor.getValue())
+        .containsKey("GET_/pung/{message}")
+        .doesNotContainKey("GET_/pung/hello");
+    }
+
+    @Test
+    void shouldFallbackToConcretePathKey_whenOperationIdIsNotInSpec() {
+      var attributes = JsonMapper.shared().readTree(
+        // language=json
+        """
+        {"openapi.operation.id":"unknownOp","http.request.method":"GET","url.path":"/pung/hello"}
+        """
+      );
+      openApiTestContext = openApiTestContext.withOpenTelemetryData(
+        Set.of(new OpenTelemetryData("spanId", "traceId", attributes))
+      );
+
+      var paths = new Paths();
+      paths.addPathItem("/pung/{message}", new PathItem().get(new Operation()));
+      doReturn(paths).when(openAPIMock).getPaths();
+
+      ArgumentCaptor<Map<String, List<OpenTelemetryData>>> telemetryCaptor =
+        captor();
+      doReturn(emptySet())
+        .when(openApiCoverageCalculationCoordinatorMock)
+        .calculate(any(), telemetryCaptor.capture());
+
+      fixture.calculateCoverage(openApiTestContext);
+
+      assertThat(telemetryCaptor.getValue())
+        .containsKey("GET_/pung/hello")
+        .doesNotContainKey("GET_/pung/{message}");
+    }
+
+    @Test
+    void shouldFilterOut_whenOperationIdIsUnknownAndUrlAttributesAreMissing() {
+      var attributes = JsonMapper.shared().readTree(
+        // language=json
+        """
+        {"openapi.operation.id":"unknownOp"}
+        """
+      );
+      openApiTestContext = openApiTestContext.withOpenTelemetryData(
+        Set.of(new OpenTelemetryData("spanId", "traceId", attributes))
+      );
+
+      var paths = new Paths();
+      paths.addPathItem("/pung/{message}", new PathItem().get(new Operation()));
+      doReturn(paths).when(openAPIMock).getPaths();
+
+      ArgumentCaptor<Map<String, List<OpenTelemetryData>>> telemetryCaptor =
+        captor();
+      doReturn(emptySet())
+        .when(openApiCoverageCalculationCoordinatorMock)
+        .calculate(any(), telemetryCaptor.capture());
+
+      fixture.calculateCoverage(openApiTestContext);
+
+      assertThat(telemetryCaptor.getValue()).isEmpty();
     }
   }
 }

--- a/microservices/openapi-coverage-stream/src/test/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/OpenApiCoverageServiceUnitTest.java
+++ b/microservices/openapi-coverage-stream/src/test/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/service/OpenApiCoverageServiceUnitTest.java
@@ -52,6 +52,9 @@ import tools.jackson.databind.json.JsonMapper;
 class OpenApiCoverageServiceUnitTest {
 
   @Mock
+  private OpenApiCoverageStreamProperties openApiCoverageStreamPropertiesMock;
+
+  @Mock
   private OpenApiCoverageCalculationCoordinator openApiCoverageCalculationCoordinatorMock;
 
   private OpenApiCoverageService fixture;
@@ -59,7 +62,7 @@ class OpenApiCoverageServiceUnitTest {
   @BeforeEach
   void beforeEachSetup() {
     fixture = new OpenApiCoverageService(
-      new OpenApiCoverageStreamProperties(),
+      openApiCoverageStreamPropertiesMock,
       openApiCoverageCalculationCoordinatorMock
     );
   }
@@ -207,6 +210,10 @@ class OpenApiCoverageServiceUnitTest {
 
     @Test
     void shouldGroupTelemetryByTemplateKey_whenOperationIdIsKnown() {
+      doReturn("openapi.operation.id")
+        .when(openApiCoverageStreamPropertiesMock)
+        .getOperationIdAttribute();
+
       var attributes = JsonMapper.shared().readTree(
         // language=json
         """

--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,11 @@
     <!-- Dependency Management -->
     <jackson.version>3.1.4</jackson.version>
     <jackson-v2.version>2.22</jackson-v2.version>
+    <junit.version>6.1.0</junit.version>
     <license-maven-plugin.version>2.7.1</license-maven-plugin.version>
     <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
     <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
+    <mockito.version>5.23.0</mockito.version>
     <org.projectlombok.version>1.18.46</org.projectlombok.version>
     <sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
     <spring-boot.version>4.1.0</spring-boot.version>
@@ -87,7 +89,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>6.1.0</version>
+        <version>${junit.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -115,6 +117,13 @@
         <groupId>io.github.bbortt.snow-white</groupId>
         <artifactId>commons</artifactId>
         <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
+        <scope>test</scope>
       </dependency>
 
       <dependency>

--- a/toolkit/annotation-api/pom.xml
+++ b/toolkit/annotation-api/pom.xml
@@ -21,5 +21,46 @@
   <artifactId>annotation-api</artifactId>
   <packaging>jar</packaging>
 
-  <properties />
+  <dependencies>
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/toolkit/annotation-api/src/main/java/io/github/bbortt/snow/white/toolkit/annotation/SnowWhiteInformation.java
+++ b/toolkit/annotation-api/src/main/java/io/github/bbortt/snow/white/toolkit/annotation/SnowWhiteInformation.java
@@ -11,14 +11,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target(ElementType.METHOD)
+@Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface SnowWhiteInformation {
-  String serviceName();
+  String serviceName() default "";
 
-  String apiName();
+  String apiName() default "";
 
-  String apiVersion();
+  String apiVersion() default "";
 
   String operationId() default "";
 }

--- a/toolkit/annotation-api/src/main/java/io/github/bbortt/snow/white/toolkit/annotation/SnowWhiteInformationExtractor.java
+++ b/toolkit/annotation-api/src/main/java/io/github/bbortt/snow/white/toolkit/annotation/SnowWhiteInformationExtractor.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Timon Borter <timon.borter@gmx.ch>
+ * Licensed under the Polyform Small Business License 1.0.0
+ * See LICENSE file for full details.
+ */
+
+package io.github.bbortt.snow.white.toolkit.annotation;
+
+import static java.util.Objects.nonNull;
+import static lombok.AccessLevel.PRIVATE;
+
+import java.util.function.Function;
+import lombok.NoArgsConstructor;
+import org.jspecify.annotations.Nullable;
+
+@NoArgsConstructor(access = PRIVATE)
+public class SnowWhiteInformationExtractor {
+
+  public static String resolveServiceName(
+    @Nullable SnowWhiteInformation methodAnnotation,
+    @Nullable SnowWhiteInformation classAnnotation
+  ) {
+    return resolve(
+      methodAnnotation,
+      classAnnotation,
+      SnowWhiteInformation::serviceName
+    );
+  }
+
+  public static String resolveApiName(
+    @Nullable SnowWhiteInformation methodAnnotation,
+    @Nullable SnowWhiteInformation classAnnotation
+  ) {
+    return resolve(
+      methodAnnotation,
+      classAnnotation,
+      SnowWhiteInformation::apiName
+    );
+  }
+
+  public static String resolveApiVersion(
+    @Nullable SnowWhiteInformation methodAnnotation,
+    @Nullable SnowWhiteInformation classAnnotation
+  ) {
+    return resolve(
+      methodAnnotation,
+      classAnnotation,
+      SnowWhiteInformation::apiVersion
+    );
+  }
+
+  public static String resolveOperationId(
+    @Nullable SnowWhiteInformation methodAnnotation,
+    @Nullable SnowWhiteInformation classAnnotation
+  ) {
+    return resolve(
+      methodAnnotation,
+      classAnnotation,
+      SnowWhiteInformation::operationId
+    );
+  }
+
+  private static String resolve(
+    @Nullable SnowWhiteInformation methodLevel,
+    @Nullable SnowWhiteInformation classLevel,
+    Function<SnowWhiteInformation, String> getter
+  ) {
+    if (methodLevel != null && hasText(getter.apply(methodLevel))) {
+      return getter.apply(methodLevel);
+    }
+
+    if (classLevel != null) {
+      return getter.apply(classLevel);
+    }
+
+    return "";
+  }
+
+  private static boolean hasText(@Nullable String str) {
+    return nonNull(str) && !str.isBlank();
+  }
+}

--- a/toolkit/annotation-api/src/test/java/io/github/bbortt/snow/white/toolkit/annotation/SnowWhiteInformationExtractorUnitTest.java
+++ b/toolkit/annotation-api/src/test/java/io/github/bbortt/snow/white/toolkit/annotation/SnowWhiteInformationExtractorUnitTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2026 Timon Borter <timon.borter@gmx.ch>
+ * Licensed under the Polyform Small Business License 1.0.0
+ * See LICENSE file for full details.
+ */
+
+package io.github.bbortt.snow.white.toolkit.annotation;
+
+import static io.github.bbortt.snow.white.toolkit.annotation.SnowWhiteInformationExtractor.resolveApiName;
+import static io.github.bbortt.snow.white.toolkit.annotation.SnowWhiteInformationExtractor.resolveApiVersion;
+import static io.github.bbortt.snow.white.toolkit.annotation.SnowWhiteInformationExtractor.resolveOperationId;
+import static io.github.bbortt.snow.white.toolkit.annotation.SnowWhiteInformationExtractor.resolveServiceName;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class SnowWhiteInformationExtractorUnitTest {
+
+  private static SnowWhiteInformation annotationWith(
+    String serviceName,
+    String apiName,
+    String apiVersion,
+    String operationId
+  ) {
+    SnowWhiteInformation annotation = mock(SnowWhiteInformation.class);
+    when(annotation.serviceName()).thenReturn(serviceName);
+    when(annotation.apiName()).thenReturn(apiName);
+    when(annotation.apiVersion()).thenReturn(apiVersion);
+    when(annotation.operationId()).thenReturn(operationId);
+    return annotation;
+  }
+
+  @Nested
+  class ResolveServiceNameTest {
+
+    @Test
+    void returnsMethodLevelValueWhenPresent() {
+      SnowWhiteInformation method = annotationWith(
+        "method-service",
+        "",
+        "",
+        ""
+      );
+      SnowWhiteInformation clazz = annotationWith("class-service", "", "", "");
+
+      assertThat(resolveServiceName(method, clazz)).isEqualTo("method-service");
+    }
+
+    @Test
+    void fallsBackToClassLevelWhenMethodValueIsBlank() {
+      SnowWhiteInformation method = annotationWith("", "", "", "");
+      SnowWhiteInformation clazz = annotationWith("class-service", "", "", "");
+
+      assertThat(resolveServiceName(method, clazz)).isEqualTo("class-service");
+    }
+
+    @Test
+    void fallsBackToClassLevelWhenMethodAnnotationIsNull() {
+      SnowWhiteInformation clazz = annotationWith("class-service", "", "", "");
+
+      assertThat(resolveServiceName(null, clazz)).isEqualTo("class-service");
+    }
+
+    @Test
+    void returnsEmptyStringWhenBothAnnotationsAreNull() {
+      assertThat(resolveServiceName(null, null)).isEmpty();
+    }
+
+    @Test
+    void returnsEmptyStringWhenOnlyMethodAnnotationIsNullAndClassValueIsBlank() {
+      SnowWhiteInformation clazz = annotationWith("", "", "", "");
+
+      assertThat(resolveServiceName(null, clazz)).isEmpty();
+    }
+  }
+
+  @Nested
+  class ResolveApiNameTest {
+
+    @Test
+    void returnsMethodLevelValueWhenPresent() {
+      SnowWhiteInformation method = annotationWith("", "method-api", "", "");
+      SnowWhiteInformation clazz = annotationWith("", "class-api", "", "");
+
+      assertThat(resolveApiName(method, clazz)).isEqualTo("method-api");
+    }
+
+    @Test
+    void fallsBackToClassLevelWhenMethodValueIsBlank() {
+      SnowWhiteInformation method = annotationWith("", "", "", "");
+      SnowWhiteInformation clazz = annotationWith("", "class-api", "", "");
+
+      assertThat(resolveApiName(method, clazz)).isEqualTo("class-api");
+    }
+
+    @Test
+    void fallsBackToClassLevelWhenMethodAnnotationIsNull() {
+      SnowWhiteInformation clazz = annotationWith("", "class-api", "", "");
+
+      assertThat(resolveApiName(null, clazz)).isEqualTo("class-api");
+    }
+
+    @Test
+    void returnsEmptyStringWhenBothAnnotationsAreNull() {
+      assertThat(resolveApiName(null, null)).isEmpty();
+    }
+
+    @Test
+    void returnsEmptyStringWhenOnlyMethodAnnotationIsNullAndClassValueIsBlank() {
+      SnowWhiteInformation clazz = annotationWith("", "", "", "");
+
+      assertThat(resolveApiName(null, clazz)).isEmpty();
+    }
+  }
+
+  @Nested
+  class ResolveApiVersionTest {
+
+    @Test
+    void returnsMethodLevelValueWhenPresent() {
+      SnowWhiteInformation method = annotationWith("", "", "v2", "");
+      SnowWhiteInformation clazz = annotationWith("", "", "v1", "");
+
+      assertThat(resolveApiVersion(method, clazz)).isEqualTo("v2");
+    }
+
+    @Test
+    void fallsBackToClassLevelWhenMethodValueIsBlank() {
+      SnowWhiteInformation method = annotationWith("", "", "", "");
+      SnowWhiteInformation clazz = annotationWith("", "", "v1", "");
+
+      assertThat(resolveApiVersion(method, clazz)).isEqualTo("v1");
+    }
+
+    @Test
+    void fallsBackToClassLevelWhenMethodAnnotationIsNull() {
+      SnowWhiteInformation clazz = annotationWith("", "", "v1", "");
+
+      assertThat(resolveApiVersion(null, clazz)).isEqualTo("v1");
+    }
+
+    @Test
+    void returnsEmptyStringWhenBothAnnotationsAreNull() {
+      assertThat(resolveApiVersion(null, null)).isEmpty();
+    }
+
+    @Test
+    void returnsEmptyStringWhenOnlyMethodAnnotationIsNullAndClassValueIsBlank() {
+      SnowWhiteInformation clazz = annotationWith("", "", "", "");
+
+      assertThat(resolveApiVersion(null, clazz)).isEmpty();
+    }
+  }
+
+  @Nested
+  class ResolveOperationIdTest {
+
+    public static Stream<Arguments> resolvedOperationId() {
+      return Stream.of(
+        arguments("method-op", "class-op", "method-op"),
+        arguments(null, "class-op", "class-op"),
+        arguments("", "class-op", "class-op"),
+        arguments(" ", "class-op", "class-op"),
+        arguments("method-op", "class-op", "method-op")
+      );
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void resolvedOperationId(
+      String methodValue,
+      String clazzValue,
+      String result
+    ) {
+      SnowWhiteInformation method = annotationWith("", "", "", methodValue);
+      SnowWhiteInformation clazz = annotationWith("", "", "", clazzValue);
+
+      assertThat(resolveOperationId(method, clazz)).isEqualTo(result);
+    }
+
+    @Test
+    void fallsBackToClassLevelWhenMethodAnnotationIsNull() {
+      SnowWhiteInformation clazz = annotationWith("", "", "", "class-op");
+
+      assertThat(resolveOperationId(null, clazz)).isEqualTo("class-op");
+    }
+
+    @Test
+    void returnsEmptyStringWhenBothAnnotationsAreNull() {
+      assertThat(resolveOperationId(null, null)).isEmpty();
+    }
+
+    @Test
+    void returnsEmptyStringWhenOnlyMethodAnnotationIsNullAndClassValueIsBlank() {
+      SnowWhiteInformation clazz = annotationWith("", "", "", "");
+
+      assertThat(resolveOperationId(null, clazz)).isEmpty();
+    }
+  }
+}

--- a/toolkit/spring-web-autoconfiguration/src/main/java/io/github/bbortt/snow/white/toolkit/spring/web/SnowWhiteAutoConfiguration.java
+++ b/toolkit/spring-web-autoconfiguration/src/main/java/io/github/bbortt/snow/white/toolkit/spring/web/SnowWhiteAutoConfiguration.java
@@ -12,6 +12,7 @@ import static io.github.bbortt.snow.white.toolkit.spring.web.SnowWhiteAutoConfig
 import io.github.bbortt.snow.white.toolkit.spring.web.config.InterceptorConfig;
 import io.github.bbortt.snow.white.toolkit.spring.web.config.SpringWebInterceptorProperties;
 import io.github.bbortt.snow.white.toolkit.spring.web.interceptor.OpenApiInformationEnhancer;
+import io.github.bbortt.snow.white.toolkit.spring.web.validation.SnowWhiteAnnotationValidator;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -23,6 +24,7 @@ import org.springframework.context.annotation.Import;
   SpringWebInterceptorProperties.class,
   OpenApiInformationEnhancer.class,
   InterceptorConfig.class,
+  SnowWhiteAnnotationValidator.class,
 })
 @ConditionalOnProperty(
   prefix = PROPERTY_PREFIX,

--- a/toolkit/spring-web-autoconfiguration/src/main/java/io/github/bbortt/snow/white/toolkit/spring/web/interceptor/OpenApiInformationEnhancer.java
+++ b/toolkit/spring-web-autoconfiguration/src/main/java/io/github/bbortt/snow/white/toolkit/spring/web/interceptor/OpenApiInformationEnhancer.java
@@ -6,6 +6,10 @@
 
 package io.github.bbortt.snow.white.toolkit.spring.web.interceptor;
 
+import static io.github.bbortt.snow.white.toolkit.annotation.SnowWhiteInformationExtractor.resolveApiName;
+import static io.github.bbortt.snow.white.toolkit.annotation.SnowWhiteInformationExtractor.resolveApiVersion;
+import static io.github.bbortt.snow.white.toolkit.annotation.SnowWhiteInformationExtractor.resolveOperationId;
+import static io.github.bbortt.snow.white.toolkit.annotation.SnowWhiteInformationExtractor.resolveServiceName;
 import static java.util.Objects.isNull;
 import static org.springframework.util.StringUtils.hasText;
 
@@ -15,12 +19,14 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NullMarked;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @Slf4j
 @Component
+@NullMarked
 @RequiredArgsConstructor
 public class OpenApiInformationEnhancer implements HandlerInterceptor {
 
@@ -38,36 +44,47 @@ public class OpenApiInformationEnhancer implements HandlerInterceptor {
     if (
       !(handler instanceof HandlerMethod handlerMethod) || isNull(currentSpan)
     ) {
-      return true; // No active span, nothing to enhance
+      return true;
     }
 
-    var method = handlerMethod.getMethod();
-    if (method.isAnnotationPresent(SnowWhiteInformation.class)) {
-      var snowWhiteInformation = method.getAnnotation(
-        SnowWhiteInformation.class
-      );
+    var methodAnnotation = handlerMethod
+      .getMethod()
+      .getAnnotation(SnowWhiteInformation.class);
+    var classAnnotation = handlerMethod
+      .getBeanType()
+      .getAnnotation(SnowWhiteInformation.class);
 
-      logger.trace("Enhancing span: [{}]", snowWhiteInformation);
+    if (isNull(classAnnotation) && isNull(methodAnnotation)) {
+      return true;
+    }
 
+    logger.trace(
+      "Enhancing span: method=[{}], class=[{}]",
+      methodAnnotation,
+      classAnnotation
+    );
+
+    currentSpan.setAttribute(
+      springWebInterceptorProperties.getApiNameAttribute(),
+      resolveApiName(methodAnnotation, classAnnotation)
+    );
+    currentSpan.setAttribute(
+      springWebInterceptorProperties.getApiVersionAttribute(),
+      resolveApiVersion(methodAnnotation, classAnnotation)
+    );
+
+    if (hasText(springWebInterceptorProperties.getOtelServiceNameAttribute())) {
       currentSpan.setAttribute(
-        springWebInterceptorProperties.getApiNameAttribute(),
-        snowWhiteInformation.apiName()
-      );
-      currentSpan.setAttribute(
-        springWebInterceptorProperties.getApiVersionAttribute(),
-        snowWhiteInformation.apiVersion()
-      );
-
-      if (
-        hasText(springWebInterceptorProperties.getOtelServiceNameAttribute())
-      ) currentSpan.setAttribute(
         springWebInterceptorProperties.getOtelServiceNameAttribute(),
-        snowWhiteInformation.serviceName()
+        resolveServiceName(methodAnnotation, classAnnotation)
       );
+    }
 
-      if (hasText(snowWhiteInformation.operationId())) currentSpan.setAttribute(
+    var operationId = resolveOperationId(methodAnnotation, classAnnotation);
+    if (hasText(operationId)) {
+      currentSpan.setAttribute(
         springWebInterceptorProperties.getOperationIdAttribute(),
-        snowWhiteInformation.operationId()
+        operationId
       );
     }
 

--- a/toolkit/spring-web-autoconfiguration/src/main/java/io/github/bbortt/snow/white/toolkit/spring/web/validation/SnowWhiteAnnotationValidator.java
+++ b/toolkit/spring-web-autoconfiguration/src/main/java/io/github/bbortt/snow/white/toolkit/spring/web/validation/SnowWhiteAnnotationValidator.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Timon Borter <timon.borter@gmx.ch>
+ * Licensed under the Polyform Small Business License 1.0.0
+ * See LICENSE file for full details.
+ */
+
+package io.github.bbortt.snow.white.toolkit.spring.web.validation;
+
+import static io.github.bbortt.snow.white.toolkit.annotation.SnowWhiteInformationExtractor.resolveApiName;
+import static io.github.bbortt.snow.white.toolkit.annotation.SnowWhiteInformationExtractor.resolveApiVersion;
+import static io.github.bbortt.snow.white.toolkit.annotation.SnowWhiteInformationExtractor.resolveServiceName;
+import static java.util.Objects.nonNull;
+import static org.springframework.aop.support.AopUtils.getTargetClass;
+import static org.springframework.core.annotation.AnnotatedElementUtils.hasAnnotation;
+import static org.springframework.util.StringUtils.hasText;
+
+import io.github.bbortt.snow.white.toolkit.annotation.SnowWhiteInformation;
+import java.lang.reflect.Method;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Slf4j
+public class SnowWhiteAnnotationValidator {
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void validateOnStartup(ApplicationReadyEvent event) {
+    event
+      .getApplicationContext()
+      .getBeansWithAnnotation(Controller.class)
+      .values()
+      .forEach(bean -> validateController(getTargetClass(bean)));
+  }
+
+  private void validateController(Class<?> controllerClass) {
+    var classAnnotation = controllerClass.getAnnotation(
+      SnowWhiteInformation.class
+    );
+
+    for (var method : controllerClass.getDeclaredMethods()) {
+      if (
+        !methodIsRequestMapping(method) ||
+        !classOrMethodHasSnowWhiteInformation(classAnnotation, method)
+      ) {
+        continue;
+      }
+
+      var methodAnnotation = method.getAnnotation(SnowWhiteInformation.class);
+
+      var serviceName = resolveServiceName(methodAnnotation, classAnnotation);
+      var apiName = resolveApiName(methodAnnotation, classAnnotation);
+      var apiVersion = resolveApiVersion(methodAnnotation, classAnnotation);
+
+      if (!hasText(serviceName) || !hasText(apiName) || !hasText(apiVersion)) {
+        throw new IllegalStateException(
+          "Incomplete @SnowWhiteInformation on %s#%s: serviceName='%s', apiName='%s', apiVersion='%s'".formatted(
+            controllerClass.getSimpleName(),
+            method.getName(),
+            serviceName,
+            apiName,
+            apiVersion
+          )
+        );
+      }
+    }
+  }
+
+  private boolean classOrMethodHasSnowWhiteInformation(
+    @Nullable SnowWhiteInformation classAnnotation,
+    @NonNull Method method
+  ) {
+    return (
+      nonNull(classAnnotation) ||
+      nonNull(method.getAnnotation(SnowWhiteInformation.class))
+    );
+  }
+
+  private static boolean methodIsRequestMapping(@NonNull Method method) {
+    return !method.isSynthetic() && hasAnnotation(method, RequestMapping.class);
+  }
+}

--- a/toolkit/spring-web-autoconfiguration/src/test/java/io/github/bbortt/snow/white/toolkit/spring/web/SnowWhiteAutoConfigurationIT.java
+++ b/toolkit/spring-web-autoconfiguration/src/test/java/io/github/bbortt/snow/white/toolkit/spring/web/SnowWhiteAutoConfigurationIT.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.bbortt.snow.white.toolkit.spring.web.config.SpringWebInterceptorProperties;
 import io.github.bbortt.snow.white.toolkit.spring.web.interceptor.OpenApiInformationEnhancer;
+import io.github.bbortt.snow.white.toolkit.spring.web.validation.SnowWhiteAnnotationValidator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,6 +24,9 @@ class SnowWhiteAutoConfigurationIT {
   @Autowired
   private SpringWebInterceptorProperties springWebInterceptorProperties;
 
+  @Autowired
+  private SnowWhiteAnnotationValidator snowWhiteAnnotationValidator;
+
   @Test
   void propertiesAreLoaded() {
     assertThat(springWebInterceptorProperties).isNotNull();
@@ -31,5 +35,10 @@ class SnowWhiteAutoConfigurationIT {
   @Test
   void aspectIsLoaded() {
     assertThat(openApiInformationEnhancer).isNotNull();
+  }
+
+  @Test
+  void validatorIsLoaded() {
+    assertThat(snowWhiteAnnotationValidator).isNotNull();
   }
 }

--- a/toolkit/spring-web-autoconfiguration/src/test/java/io/github/bbortt/snow/white/toolkit/spring/web/interceptor/OpenApiInformationEnhancerUnitTest.java
+++ b/toolkit/spring-web-autoconfiguration/src/test/java/io/github/bbortt/snow/white/toolkit/spring/web/interceptor/OpenApiInformationEnhancerUnitTest.java
@@ -100,6 +100,37 @@ class OpenApiInformationEnhancerUnitTest {
     };
   }
 
+  private static SnowWhiteInformation createOperationOnlyAnnotation(
+    String operationId
+  ) {
+    return new SnowWhiteInformation() {
+      @Override
+      public Class<SnowWhiteInformation> annotationType() {
+        return SnowWhiteInformation.class;
+      }
+
+      @Override
+      public String serviceName() {
+        return "";
+      }
+
+      @Override
+      public String apiName() {
+        return "";
+      }
+
+      @Override
+      public String apiVersion() {
+        return "";
+      }
+
+      @Override
+      public String operationId() {
+        return operationId;
+      }
+    };
+  }
+
   @BeforeEach
   void beforeEachSetup() {
     apiNameAttributeKey = "custom.api.name" + randomUUID();
@@ -134,9 +165,9 @@ class OpenApiInformationEnhancerUnitTest {
   void invocationWithNoAnnotationDoesNothing() {
     doReturn(spanMock).when(spanProviderMock).getCurrentSpan();
     doReturn(methodMock).when(handlerMethodMock).getMethod();
-    doReturn(false)
-      .when(methodMock)
-      .isAnnotationPresent(SnowWhiteInformation.class);
+    doReturn(Object.class)
+      .when(handlerMethodMock)
+      .getBeanType();
 
     fixture.preHandle(
       httpServletRequestMock,
@@ -155,6 +186,54 @@ class OpenApiInformationEnhancerUnitTest {
     var annotation = createMockAnnotation(operationId);
 
     fullMockConfiguration(annotation);
+
+    fixture.preHandle(
+      httpServletRequestMock,
+      httpServletResponseMock,
+      handlerMethodMock
+    );
+
+    verify(spanMock).setAttribute(apiNameAttributeKey, API_NAME);
+    verify(spanMock).setAttribute(apiVersionAttributeKey, API_VERSION);
+    verify(spanMock).setAttribute(serviceNameAttributeKey, SERVICE_NAME);
+    verify(spanMock).setAttribute(operationIdAttributeKey, operationId);
+  }
+
+  @Test
+  void invocationWithClassAnnotationSetsSpanAttributes() {
+    configureMockProperties(serviceNameAttributeKey, null);
+
+    doReturn(spanMock).when(spanProviderMock).getCurrentSpan();
+    doReturn(methodMock).when(handlerMethodMock).getMethod();
+    doReturn(ClassAnnotatedController.class)
+      .when(handlerMethodMock)
+      .getBeanType();
+
+    fixture.preHandle(
+      httpServletRequestMock,
+      httpServletResponseMock,
+      handlerMethodMock
+    );
+
+    verify(spanMock).setAttribute(apiNameAttributeKey, API_NAME);
+    verify(spanMock).setAttribute(apiVersionAttributeKey, API_VERSION);
+    verify(spanMock).setAttribute(serviceNameAttributeKey, SERVICE_NAME);
+    verifyNoMoreInteractions(spanMock);
+  }
+
+  @Test
+  void invocationWithClassAndMethodAnnotationMergesValues() {
+    configureMockProperties(serviceNameAttributeKey, operationIdAttributeKey);
+
+    var operationId = "methodOperationId";
+    doReturn(spanMock).when(spanProviderMock).getCurrentSpan();
+    doReturn(methodMock).when(handlerMethodMock).getMethod();
+    doReturn(createOperationOnlyAnnotation(operationId))
+      .when(methodMock)
+      .getAnnotation(SnowWhiteInformation.class);
+    doReturn(ClassAnnotatedController.class)
+      .when(handlerMethodMock)
+      .getBeanType();
 
     fixture.preHandle(
       httpServletRequestMock,
@@ -239,11 +318,18 @@ class OpenApiInformationEnhancerUnitTest {
   private void fullMockConfiguration(SnowWhiteInformation annotation) {
     doReturn(spanMock).when(spanProviderMock).getCurrentSpan();
     doReturn(methodMock).when(handlerMethodMock).getMethod();
-    doReturn(true)
-      .when(methodMock)
-      .isAnnotationPresent(SnowWhiteInformation.class);
     doReturn(annotation)
       .when(methodMock)
       .getAnnotation(SnowWhiteInformation.class);
+    doReturn(Object.class)
+      .when(handlerMethodMock)
+      .getBeanType();
   }
+
+  @SnowWhiteInformation(
+    serviceName = SERVICE_NAME,
+    apiName = API_NAME,
+    apiVersion = API_VERSION
+  )
+  private static class ClassAnnotatedController {}
 }

--- a/toolkit/spring-web-autoconfiguration/src/test/java/io/github/bbortt/snow/white/toolkit/spring/web/validation/SnowWhiteAnnotationValidatorUnitTest.java
+++ b/toolkit/spring-web-autoconfiguration/src/test/java/io/github/bbortt/snow/white/toolkit/spring/web/validation/SnowWhiteAnnotationValidatorUnitTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 Timon Borter <timon.borter@gmx.ch>
+ * Licensed under the Polyform Small Business License 1.0.0
+ * See LICENSE file for full details.
+ */
+
+package io.github.bbortt.snow.white.toolkit.spring.web.validation;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+
+import io.github.bbortt.snow.white.toolkit.annotation.SnowWhiteInformation;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@ExtendWith({ MockitoExtension.class })
+class SnowWhiteAnnotationValidatorUnitTest {
+
+  @Mock
+  private ApplicationReadyEvent eventMock;
+
+  @Mock
+  private ConfigurableApplicationContext contextMock;
+
+  private SnowWhiteAnnotationValidator fixture;
+
+  @BeforeEach
+  void beforeEachSetup() {
+    fixture = new SnowWhiteAnnotationValidator();
+    doReturn(contextMock).when(eventMock).getApplicationContext();
+  }
+
+  @Test
+  void passesValidation_whenControllerIsFullyAnnotatedAtClassLevel() {
+    doReturn(Map.of("controller", new CompleteClassAnnotatedController()))
+      .when(contextMock)
+      .getBeansWithAnnotation(Controller.class);
+
+    assertThatNoException().isThrownBy(() ->
+      fixture.validateOnStartup(eventMock)
+    );
+  }
+
+  @Test
+  void passesValidation_whenAnnotationsAreCompletedByMerge() {
+    doReturn(Map.of("controller", new MergedAnnotationController()))
+      .when(contextMock)
+      .getBeansWithAnnotation(Controller.class);
+
+    assertThatNoException().isThrownBy(() ->
+      fixture.validateOnStartup(eventMock)
+    );
+  }
+
+  @Test
+  void passesValidation_whenNoAnnotationPresent() {
+    doReturn(Map.of("controller", new UnannotatedController()))
+      .when(contextMock)
+      .getBeansWithAnnotation(Controller.class);
+
+    assertThatNoException().isThrownBy(() ->
+      fixture.validateOnStartup(eventMock)
+    );
+  }
+
+  @Test
+  void throwsIllegalStateException_whenAnnotationIsIncomplete() {
+    doReturn(Map.of("controller", new IncompleteAnnotationController()))
+      .when(contextMock)
+      .getBeansWithAnnotation(Controller.class);
+
+    assertThatThrownBy(() -> fixture.validateOnStartup(eventMock))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("Incomplete @SnowWhiteInformation");
+  }
+
+  @SnowWhiteInformation(serviceName = "svc", apiName = "api", apiVersion = "v1")
+  private static class CompleteClassAnnotatedController {
+
+    @GetMapping("/test")
+    public void endpoint() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  @SnowWhiteInformation(apiName = "api", apiVersion = "v1")
+  private static class MergedAnnotationController {
+
+    @GetMapping("/test")
+    @SnowWhiteInformation(serviceName = "svc", operationId = "doThing")
+    public void endpoint() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private static class UnannotatedController {
+
+    @GetMapping("/test")
+    public void endpoint() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  @SnowWhiteInformation(serviceName = "svc")
+  private static class IncompleteAnnotationController {
+
+    @GetMapping("/test")
+    public void endpoint() {
+      throw new UnsupportedOperationException();
+    }
+  }
+}


### PR DESCRIPTION
- `OpenApiCoverageStreamProperties` — `operationIdAttribute = "openapi.operation.id"` (configurable, matches toolkit default)
- `OpenApiCoverageService` — injects the properties; `buildOperationIdToKeyMap` indexes `operationId` → `templateKey` from the OpenAPI spec; `groupTelemetryByPath` uses the index as a fast path (groups by template key directly) and falls back to URL-path regex matching only when the operationId is absent or unknown