### PR TITLE
Fix/api sync job

### DIFF
--- a/microservices/api-sync-job/src/main/java/io/github/bbortt/snow/white/microservices/api/sync/job/service/impl/ArtifactoryApiCatalogService.java
+++ b/microservices/api-sync-job/src/main/java/io/github/bbortt/snow/white/microservices/api/sync/job/service/impl/ArtifactoryApiCatalogService.java
@@ -9,6 +9,7 @@ package io.github.bbortt.snow.white.microservices.api.sync.job.service.impl;
 import static io.github.bbortt.snow.white.commons.quality.gate.ApiType.OPENAPI;
 import static io.github.bbortt.snow.white.microservices.api.sync.job.parser.ParsingMode.STRICT;
 import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.isNull;
 
 import io.github.bbortt.snow.white.commons.openapi.InformationExtractor;
@@ -21,6 +22,8 @@ import io.github.bbortt.snow.white.microservices.api.sync.job.service.exception.
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.OpenAPIV3Parser;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
 import java.util.List;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
@@ -204,11 +207,13 @@ public class ArtifactoryApiCatalogService implements ApiCatalogService {
       var inputStream = artifactory
         .repository(repository)
         .download(filePath)
-        .doDownload()
+        .doDownload();
+      var reader = new InputStreamReader(inputStream, UTF_8)
     ) {
-      return openAPIV3Parser.readContents(
-        new String(inputStream.readAllBytes())
-      );
+      var content = new StringWriter();
+      reader.transferTo(content);
+
+      return openAPIV3Parser.readContents(content.toString());
     } catch (Exception e) {
       var errorMessage = format("Failed to parse OpenAPI from '%s'", filePath);
 

--- a/microservices/api-sync-job/src/main/java/io/github/bbortt/snow/white/microservices/api/sync/job/service/impl/ArtifactoryApiCatalogService.java
+++ b/microservices/api-sync-job/src/main/java/io/github/bbortt/snow/white/microservices/api/sync/job/service/impl/ArtifactoryApiCatalogService.java
@@ -21,6 +21,7 @@ import io.github.bbortt.snow.white.microservices.api.sync.job.service.OpenApiVal
 import io.github.bbortt.snow.white.microservices.api.sync.job.service.exception.ApiCatalogException;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.core.models.ParseOptions;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
@@ -41,6 +42,17 @@ import tools.jackson.databind.json.JsonMapper;
 @Slf4j
 @Service
 public class ArtifactoryApiCatalogService implements ApiCatalogService {
+
+  /**
+   * Only the literal `info` fields are read from parsed specs, which cannot
+   * contain `$ref` per the OpenAPI spec, so resolving is disabled to avoid
+   * the parser reaching out to the filesystem/network for every `$ref`.
+   */
+  private static final ParseOptions PARSE_OPTIONS = new ParseOptions();
+
+  static {
+    PARSE_OPTIONS.setResolve(false);
+  }
 
   private final Artifactory artifactory;
   private final ApiSyncJobProperties.ArtifactoryProperties artifactoryProperties;
@@ -213,7 +225,11 @@ public class ArtifactoryApiCatalogService implements ApiCatalogService {
       var content = new StringWriter();
       reader.transferTo(content);
 
-      return openAPIV3Parser.readContents(content.toString());
+      return openAPIV3Parser.readContents(
+        content.toString(),
+        null,
+        PARSE_OPTIONS
+      );
     } catch (Exception e) {
       var errorMessage = format("Failed to parse OpenAPI from '%s'", filePath);
 

--- a/microservices/api-sync-job/src/test/java/io/github/bbortt/snow/white/microservices/api/sync/job/service/impl/ArtifactoryApiCatalogServiceUnitTest.java
+++ b/microservices/api-sync-job/src/test/java/io/github/bbortt/snow/white/microservices/api/sync/job/service/impl/ArtifactoryApiCatalogServiceUnitTest.java
@@ -132,7 +132,9 @@ class ArtifactoryApiCatalogServiceUnitTest {
       SwaggerParseResult parseResult = new SwaggerParseResult();
       parseResult.setOpenAPI(openAPI);
 
-      doReturn(parseResult).when(openAPIV3ParserMock).readContents(anyString());
+      doReturn(parseResult)
+        .when(openAPIV3ParserMock)
+        .readContents(anyString(), any(), any());
 
       OpenApiInformation openApiInformation = new OpenApiInformation(
         "petstore-api",
@@ -246,7 +248,9 @@ class ArtifactoryApiCatalogServiceUnitTest {
       parseResult.setOpenAPI(null);
       parseResult.setMessages(List.of("Invalid OpenAPI format"));
 
-      doReturn(parseResult).when(openAPIV3ParserMock).readContents(anyString());
+      doReturn(parseResult)
+        .when(openAPIV3ParserMock)
+        .readContents(anyString(), any(), any());
 
       doReturn(repositoryHandle).when(artifactoryMock).repository("api-specs");
 
@@ -392,7 +396,9 @@ class ArtifactoryApiCatalogServiceUnitTest {
       SwaggerParseResult parseResult = new SwaggerParseResult();
       parseResult.setOpenAPI(openAPI);
 
-      doReturn(parseResult).when(openAPIV3ParserMock).readContents(anyString());
+      doReturn(parseResult)
+        .when(openAPIV3ParserMock)
+        .readContents(anyString(), any(), any());
 
       OpenApiInformation openApiInformation = new OpenApiInformation(
         "petstore-api",
@@ -467,7 +473,7 @@ class ArtifactoryApiCatalogServiceUnitTest {
 
       doReturn(parseResult)
         .when(openAPIV3ParserMock)
-        .readContents(openApiContent);
+        .readContents(eq(openApiContent), any(), any());
 
       OpenApiInformation openApiInformation = new OpenApiInformation(
         title.toLowerCase().replace(" ", "-"),


### PR DESCRIPTION
little fixes to the `api-sync-job`:
* do not fetch references for meta information parsing
* resolve a double memory copy issue