### PR TITLE
remove invalid group-by key from dependabot npm grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,7 +27,6 @@ updates:
       - 'status:ready-for-review'
     groups:
       workspace-dependencies:
-        group-by: 'dependency-name'
         patterns:
           - '*'
     ignore:


### PR DESCRIPTION
The workspace-dependencies group used an unsupported `group-by` key, causing dependabot to fall back to one PR per dependency, instead of a single grouped PR for the root `pnpm` workspace.