### PR TITLE
grafana tempo organization id

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -134,12 +134,6 @@ jobs:
       matrix:
         service: [api-gateway, api-sync-job, openapi-coverage-stream]
       fail-fast: false
-    services:
-      wiremock:
-        image: index.docker.io/wiremock/wiremock@sha256:53dd996e0625bbaa906102d21fbfe029a209e92fd33862f73b3885a386e5db57
-        ports:
-          - '9000:8080'
-        options: --name wiremock
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -153,6 +147,8 @@ jobs:
           cache: maven
           distribution: 'temurin'
           java-version: 25
+      - name: Create Docker Network
+        run: docker network create github_actions
       - name: Rebuild JAR
         run: |
           ./mvnw -B clean install \
@@ -169,19 +165,19 @@ jobs:
             --build-arg BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
             --build-arg PROJECT_VERSION="${{ github.sha }}" \
             microservices/${{ matrix.service }}
-      - name: Start Telemetry Backend
-        if: ${{ matrix.service == 'openapi-coverage-stream' }}
+      - name: Start Required Services
         run: |
-          docker_network=$(docker network ls --filter name=^github_network --format "{{.Name}}")
-          COMPOSE_NETWORK_NAME=${docker_network} docker compose \
-            -f microservices/openapi-coverage-stream/src/apptest/resources/docker-compose-apptest.yaml \
-            up -d --no-deps kafka otel-collector grafana influxdb
+          compose_file=microservices/${{ matrix.service }}/src/apptest/resources/docker-compose-apptest.yaml
+          # kafka.ui is a dev-convenience dashboard, never needed by the tests themselves - skip it to keep resource usage low.
+          services=$(docker compose -f "$compose_file" config --services | grep -v '^kafka\.ui$')
+          docker compose -f "$compose_file" up -d --no-deps --wait --wait-timeout 120 $services
+        env:
+          COMPOSE_NETWORK_NAME: github_actions
       - name: Test ${{ matrix.service }} Image
         run: |
-          docker_network=$(docker network ls --filter name=^github_network --format "{{.Name}}")
           ./mvnw -B verify \
             -Papptest \
-            -Ddocker.network=${docker_network} \
+            -Ddocker.network=github_actions \
             -Dimage.tag=${{ github.sha }} \
             -pl :${{ matrix.service }}
   native-tests:
@@ -202,46 +198,6 @@ jobs:
             report-coordinator-api,
           ]
       fail-fast: false
-    services:
-      kafka:
-        image: index.docker.io/confluentinc/cp-kafka@sha256:acbbf674f2ed40e5d0a8ca51beb0f00692c866fc22b5ce06f8cadbdc54cd4436
-        env:
-          # Cluster / broker identity
-          KAFKA_NODE_ID: 1
-          KAFKA_BROKER_ID: 1
-          CLUSTER_ID: 'NjZmNTk0MDc5OWZjNDQzYW' # run "kafka-storage random-uuid"
-          KAFKA_PROCESS_ROLES: 'broker,controller'
-          # Listener setup
-          KAFKA_LISTENERS: 'PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094'
-          KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,EXTERNAL://kafka:9094'
-          KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT'
-          KAFKA_CONTROLLER_QUORUM_VOTERS: '1@kafka:9093'
-          KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
-          # Other essential configs
-          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-          KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-          KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-          KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-          KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'
-        ports:
-          - '9092:9092'
-          - '9094:9094'
-      postgres:
-        image: index.docker.io/library/postgres@sha256:54451ecb8ab38c24c3ec123f2fd501303a3a1856a5c66e98cecf2460d5e1e9d7
-        env:
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - '5432:5432'
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      wiremock:
-        image: index.docker.io/wiremock/wiremock@sha256:53dd996e0625bbaa906102d21fbfe029a209e92fd33862f73b3885a386e5db57
-        ports:
-          - '9000:8080'
-        options: --name wiremock
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -254,11 +210,8 @@ jobs:
           cache: maven
           distribution: 'temurin'
           java-version: 25
-      - name: Init PostgreSQL Databases
-        if: ${{ matrix.service == 'api-index-api' || matrix.service == 'quality-gate-api' || matrix.service == 'report-coordinator-api' }}
-        run: psql -h localhost -U postgres -d postgres -f ./dev/postgres/init.sql
-        env:
-          PGPASSWORD: postgres
+      - name: Create Docker Network
+        run: docker network create github_actions
       - name: Rebuild JAR
         run: |
           ./mvnw -B clean install \
@@ -275,12 +228,19 @@ jobs:
             -Dimage.tag=${{ github.sha }} \
             -DskipTests \
             -pl :${{ matrix.service }}
+      - name: Start Required Services
+        run: |
+          compose_file=microservices/${{ matrix.service }}/src/apptest/resources/docker-compose-apptest.yaml
+          # kafka.ui is a dev-convenience dashboard, never needed by the tests themselves - skip it to keep resource usage low.
+          services=$(docker compose -f "$compose_file" config --services | grep -v '^kafka\.ui$')
+          docker compose -f "$compose_file" up -d --no-deps --wait --wait-timeout 120 $services
+        env:
+          COMPOSE_NETWORK_NAME: github_actions
       - name: Test Native ${{ matrix.service }} Image
         run: |
-          docker_network=$(docker network ls --filter name=^github_network --format "{{.Name}}")
           ./mvnw -B verify \
             -Papptest \
-            -Ddocker.network=${docker_network} \
+            -Ddocker.network=github_actions \
             -Dimage.tag=${{ github.sha }} \
             -pl :${{ matrix.service }}
   dependency-review:

--- a/microservices/api-index-api/src/apptest/resources/docker-compose-apptest.yaml
+++ b/microservices/api-index-api/src/apptest/resources/docker-compose-apptest.yaml
@@ -17,6 +17,11 @@ services:
       - ../../../../../dev/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql
     ports:
       - '5432:5432'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U snow-white -d postgres']
+      interval: 2s
+      timeout: 5s
+      retries: 12
     restart: on-failure
     networks:
       - default

--- a/microservices/openapi-coverage-stream/README.md
+++ b/microservices/openapi-coverage-stream/README.md
@@ -42,12 +42,13 @@ The service fails to start if neither, or both, are configured.
 
 <!-- markdownlint-disable markdownlint-sentences-per-line -->
 
-| Property         | Description                                                                                                 | Example Value       |
-| ---------------- | ----------------------------------------------------------------------------------------------------------- | ------------------- |
-| `TEMPO_URL`      | URL of the Grafana Tempo instance used to read telemetry data.                                              | <http://tempo:3200> |
-| `TEMPO_TOKEN`    | Bearer token used to authenticate against Tempo. Mutually exclusive with `TEMPO_USERNAME`/`TEMPO_PASSWORD`. | `my-token`          |
-| `TEMPO_USERNAME` | Username used for HTTP Basic authentication against Tempo. Requires `TEMPO_PASSWORD`.                       | `snow-white`        |
-| `TEMPO_PASSWORD` | Password used for HTTP Basic authentication against Tempo. Requires `TEMPO_USERNAME`.                       | `my-password`       |
+| Property         | Description                                                                                                                                                                                                                                                  | Example Value       |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------- |
+| `TEMPO_URL`      | URL of the Grafana Tempo instance used to read telemetry data.                                                                                                                                                                                               | <http://tempo:3200> |
+| `TEMPO_TOKEN`    | Bearer token used to authenticate against Tempo. Mutually exclusive with `TEMPO_USERNAME`/`TEMPO_PASSWORD`.                                                                                                                                                  | `my-token`          |
+| `TEMPO_USERNAME` | Username used for HTTP Basic authentication against Tempo. Requires `TEMPO_PASSWORD`.                                                                                                                                                                        | `snow-white`        |
+| `TEMPO_PASSWORD` | Password used for HTTP Basic authentication against Tempo. Requires `TEMPO_USERNAME`.                                                                                                                                                                        | `my-password`       |
+| `TEMPO_ORG_ID`   | Optional. Tenant sent as the `X-Scope-OrgID` header on every request, required by Tempo instances running with [multi-tenancy](https://grafana.com/docs/tempo/latest/operations/manage-advanced-systems/multitenancy/) enabled. Omitted entirely when unset. | `snow-white`        |
 
 <!-- markdownlint-enable markdownlint-sentences-per-line -->
 

--- a/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/config/TempoProperties.java
+++ b/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/config/TempoProperties.java
@@ -21,4 +21,15 @@ public class TempoProperties {
   private String username;
   private String password;
   private String token;
+
+  /**
+   * Tenant identifier sent as the {@code X-Scope-OrgID} header on every request,
+   * for Tempo instances running with multi-tenancy enabled.
+   * <p>
+   * Optional - omitted entirely when unset,
+   * which is correct for single-tenant Tempo instances.
+   *
+   * @see <a href="https://grafana.com/docs/tempo/latest/operations/manage-advanced-systems/multitenancy/">Tempo multi-tenancy</a>
+   */
+  private String orgId;
 }

--- a/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/config/TempoRestClientConfig.java
+++ b/microservices/openapi-coverage-stream/src/main/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/config/TempoRestClientConfig.java
@@ -20,6 +20,12 @@ import org.springframework.web.client.RestClient;
 @Conditional(TempoConfiguredCondition.class)
 public class TempoRestClientConfig {
 
+  /**
+   * Tempo's multi-tenancy header - see
+   * <a href="https://grafana.com/docs/tempo/latest/operations/manage-advanced-systems/multitenancy/">Tempo multi-tenancy</a>
+   */
+  private static final String X_SCOPE_ORG_ID = "X-Scope-OrgID";
+
   @Bean
   public RestClient tempoRestClient(TempoProperties tempoProperties) {
     var builder = RestClient.builder().baseUrl(tempoProperties.getUrl());
@@ -36,6 +42,10 @@ public class TempoRestClientConfig {
           tempoProperties.getPassword()
         )
       );
+    }
+
+    if (hasText(tempoProperties.getOrgId())) {
+      builder.defaultHeader(X_SCOPE_ORG_ID, tempoProperties.getOrgId());
     }
 
     return builder.build();

--- a/microservices/openapi-coverage-stream/src/test/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/config/TempoMultiTenancyIT.java
+++ b/microservices/openapi-coverage-stream/src/test/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/config/TempoMultiTenancyIT.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Timon Borter <timon.borter@gmx.ch>
+ * Licensed under the Polyform Small Business License 1.0.0
+ * See LICENSE file for full details.
+ */
+
+package io.github.bbortt.snow.white.microservices.openapi.coverage.stream.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.HttpClientErrorException;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+/**
+ * Reproduces the production incident directly: a real Tempo instance running with
+ * {@code multitenancy_enabled: true} rejects every request that doesn't carry an
+ * {@code X-Scope-OrgID} header with {@code 401 Unauthorized: "no org id"} - regardless of
+ * whether the request is otherwise correctly authenticated.
+ *
+ * @see <a href="https://grafana.com/docs/tempo/latest/operations/manage-advanced-systems/multitenancy/">Tempo multi-tenancy</a>
+ */
+class TempoMultiTenancyIT {
+
+  private static final int TEMPO_HTTP_PORT = 3200;
+
+  private static final GenericContainer<?> TEMPO_CONTAINER =
+    new GenericContainer<>(DockerImageName.parse("grafana/tempo:2.6.1"))
+      .withCopyFileToContainer(
+        MountableFile.forClasspathResource("tempo/tempo-multitenant.yaml"),
+        "/etc/tempo.yaml"
+      )
+      .withCommand("-config.file=/etc/tempo.yaml")
+      .withExposedPorts(TEMPO_HTTP_PORT)
+      .waitingFor(Wait.forLogMessage(".*Tempo started.*\\n", 1));
+
+  static {
+    TEMPO_CONTAINER.start();
+  }
+
+  private TempoProperties tempoProperties;
+
+  private TempoRestClientConfig fixture;
+
+  @BeforeEach
+  void beforeEachSetup() {
+    tempoProperties = new TempoProperties();
+    tempoProperties.setUrl(
+      "http://%s:%s".formatted(
+        TEMPO_CONTAINER.getHost(),
+        TEMPO_CONTAINER.getMappedPort(TEMPO_HTTP_PORT)
+      )
+    );
+    tempoProperties.setToken("test-token");
+
+    fixture = new TempoRestClientConfig();
+  }
+
+  private static final String SEARCH_PATH =
+    "/api/search?q={q}&start={start}&end={end}&limit={limit}";
+
+  @Test
+  void shouldReturnUnauthorized_whenOrgIdNotConfiguredAgainstMultiTenantTempo() {
+    var now = Instant.now().getEpochSecond();
+
+    assertThatThrownBy(() ->
+      fixture
+        .tempoRestClient(tempoProperties)
+        .get()
+        .uri(SEARCH_PATH, "{}", now - 3600, now, 1)
+        .retrieve()
+        .toBodilessEntity()
+    )
+      .isInstanceOf(HttpClientErrorException.Unauthorized.class)
+      .hasMessageContaining("no org id");
+  }
+
+  @Test
+  void shouldSucceed_whenOrgIdConfiguredAgainstMultiTenantTempo() {
+    tempoProperties.setOrgId("snow-white");
+    var now = Instant.now().getEpochSecond();
+
+    var response = fixture
+      .tempoRestClient(tempoProperties)
+      .get()
+      .uri(SEARCH_PATH, "{}", now - 3600, now, 1)
+      .retrieve()
+      .toEntity(String.class);
+
+    assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+  }
+}

--- a/microservices/openapi-coverage-stream/src/test/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/config/TempoRestClientConfigUnitTest.java
+++ b/microservices/openapi-coverage-stream/src/test/java/io/github/bbortt/snow/white/microservices/openapi/coverage/stream/config/TempoRestClientConfigUnitTest.java
@@ -6,6 +6,7 @@
 
 package io.github.bbortt.snow.white.microservices.openapi.coverage.stream.config;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
@@ -85,6 +86,55 @@ class TempoRestClientConfigUnitTest {
         getRequestedFor(urlEqualTo("/api/search")).withHeader(
           AUTHORIZATION,
           equalTo("Basic " + expectedCredentials)
+        )
+      );
+    }
+  }
+
+  /**
+   * Tempo requires the {@code X-Scope-OrgID} header on every request when multi-tenancy is
+   * enabled - otherwise it rejects the request with {@code 401 Unauthorized: "no org id"}.
+   *
+   * @see <a href="https://grafana.com/docs/tempo/latest/operations/manage-advanced-systems/multitenancy/">Tempo multi-tenancy</a>
+   */
+  @Nested
+  class OrgIdHeaderTest {
+
+    @Test
+    void shouldSendOrgIdHeader_whenConfigured() {
+      tempoProperties.setToken("my-token");
+      tempoProperties.setOrgId("my-tenant");
+
+      fixture
+        .tempoRestClient(tempoProperties)
+        .get()
+        .uri("/api/search")
+        .retrieve()
+        .toBodilessEntity();
+
+      wireMockServer.verify(
+        getRequestedFor(urlEqualTo("/api/search")).withHeader(
+          "X-Scope-OrgID",
+          equalTo("my-tenant")
+        )
+      );
+    }
+
+    @Test
+    void shouldNotSendOrgIdHeader_whenNotConfigured() {
+      tempoProperties.setToken("my-token");
+
+      fixture
+        .tempoRestClient(tempoProperties)
+        .get()
+        .uri("/api/search")
+        .retrieve()
+        .toBodilessEntity();
+
+      wireMockServer.verify(
+        getRequestedFor(urlEqualTo("/api/search")).withHeader(
+          "X-Scope-OrgID",
+          absent()
         )
       );
     }

--- a/microservices/openapi-coverage-stream/src/test/resources/tempo/tempo-multitenant.yaml
+++ b/microservices/openapi-coverage-stream/src/test/resources/tempo/tempo-multitenant.yaml
@@ -1,0 +1,23 @@
+multitenancy_enabled: true
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        http:
+        grpc:
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/traces
+    wal:
+      path: /var/tempo/wal
+
+compactor:
+  compaction:
+    block_retention: 1h

--- a/microservices/quality-gate-api/src/apptest/resources/docker-compose-apptest.yaml
+++ b/microservices/quality-gate-api/src/apptest/resources/docker-compose-apptest.yaml
@@ -17,6 +17,11 @@ services:
       - ../../../../../dev/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql
     ports:
       - '5432:5432'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U snow-white -d postgres']
+      interval: 2s
+      timeout: 5s
+      retries: 12
     restart: on-failure
     networks:
       - default


### PR DESCRIPTION
Grafana Tempo,
when running with multi-tenancy enabled,
requires an `X-Scope-OrgID` header on every request.
`openapi-coverage-stream` never sent one,
so a multi-tenant production Tempo instance rejected every query.

Resolves [reported "bug"](https://github.com/bbortt/snow-white/issues/1697#issuecomment-5201051632).